### PR TITLE
updating manifest.mf generation to use a template manifiest.mf instead

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -51,34 +51,23 @@
   </dependencies>
 
   <build>
+	
+	<resources>
+		 <resource>
+		     <directory>src/main/resources</directory>
+		     <filtering>true</filtering>
+		 </resource>
+	</resources>
+
     <plugins>
      <plugin>
        <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>  
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestFile>target/classes/META-INF/MANIFEST.MF</manifestFile>
           </archive> 
         </configuration>
      </plugin> 
-     <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>1.4.0</version>
-        <configuration>
-           <instructions>
-            <Import-Package>!net.sf.cglib.core,!net.sf.cglib.proxy,*</Import-Package>
-           </instructions>
-        </configuration>
-        <executions>
-            <execution>
-                <id>bundle-manifest</id>
-                <phase>process-classes</phase>
-                <goals>
-                    <goal>manifest</goal>
-                </goals>
-            </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/core/src/main/resources/META-INF/MANIFEST.MF
+++ b/core/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,15 @@
+Manifest-Version: 1.0
+Archiver-Version: Plexus Archiver
+Created-By: ${java.version} (${java.vendor})
+Built-By: ${user.name}
+Build-Jdk: ${java.version}
+Export-Package: org.modelmapper.internal.util;uses:="org.modelmapper.spi";version="${project.version}",org.modelmapper.convention;uses:="org.modelmapper.spi";version="${project.version}",org.modelmapper.internal.converter;uses:="org.modelmapper.internal.util,org.modelmapper.spi,org.modelmapper.internal,org.modelmapper";version="${project.version}",org.modelmapper.config;uses:="org.modelmapper.spi,org.modelmapper";version="${project.version}",org.modelmapper.spi;uses:="org.modelmapper.internal.util,org.modelmapper";version="${project.version}",org.modelmapper.internal;uses:="org.modelmapper.internal.cglib.proxy,org.modelmapper.internal.converter,org.modelmapper.spi,org.modelmapper.internal.util,org.modelmapper.convention,org.modelmapper.config,org.modelmapper.internal.cglib.core,org.modelmapper,org.modelmapper.builder";version="${project.version}",org.modelmapper.builder;uses:="org.modelmapper";version="${project.version}",org.modelmapper;uses:="org.modelmapper.internal.util,org.modelmapper.config,org.modelmapper.spi,org.modelmapper.internal,org.modelmapper.builder";version="${project.version}",org.modelmapper.internal.cglib.proxy;uses:="org.modelmapper.internal.cglib.core,org.modelmapper.internal.asm,org.modelmapper.internal.asm.signature";version="${project.version}",org.modelmapper.internal.cglib.core;uses:="org.modelmapper.internal.cglib.proxy,org.modelmapper.internal.asm,org.modelmapper.internal.asm.signature";version="${project.version}",org.modelmapper.internal.asm;uses:="org.modelmapper.internal.cglib.proxy,org.modelmapper.internal.cglib.core,org.modelmapper.internal.asm.signature";version="${project.version}",org.modelmapper.internal.asm.signature;uses:="org.modelmapper.internal.cglib.proxy,org.modelmapper.internal.cglib.core,org.modelmapper.internal.asm";version="${project.version}"
+Bundle-Version: ${project.version}
+Tool: Bnd-0.0.238
+Bundle-Name: ${project.name}
+Bnd-LastModified: 1350756455414
+Bundle-ManifestVersion: 2
+Bundle-Description: ${project.description}
+Bundle-License: http://apache.org/licenses/LICENSE-2.0
+Bundle-SymbolicName: ${project.artifact.groupId}.${project.artifact.artifactId}
+Import-Package: org.modelmapper;version="${project.version}",org.modelmapper.builder;version="${project.version}",org.modelmapper.config;version="${project.version}",org.modelmapper.convention;version="${project.version}",org.modelmapper.internal;version="${project.version}",org.modelmapper.internal.converter;version="${project.version}",org.modelmapper.internal.util;version="${project.version}",org.modelmapper.spi;version="${project.version}",org.modelmapper.internal.cglib.proxy;version="${project.version}",org.modelmapper.internal.cglib.core;version="${project.version}",org.modelmapper.internal.asm;version="${project.version}",org.modelmapper.internal.asm.signature;version="${project.version}"


### PR DESCRIPTION
as it was missing some shaded packages since the shading happens after
manifest generation in the maven lifecycle. 

We had much better luck integrating this jar in our osgi application
using this new manifest.mf.

Thanks for maintaining such a great lib!
