### PR TITLE
Explicit matching strategy

### DIFF
--- a/core/src/main/java/org/modelmapper/convention/ExplicitMatchingStrategy.java
+++ b/core/src/main/java/org/modelmapper/convention/ExplicitMatchingStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.convention;
+
+import org.modelmapper.spi.MatchingStrategy;
+
+/**
+ * See {@link MatchingStrategies#EXPLICIT}.
+ * 
+ * @author Jonathan Halterman
+ */
+final class ExplicitMatchingStrategy implements MatchingStrategy {
+	public boolean isExact() {
+		return true;
+	}
+
+	public boolean matches(PropertyNameInfo propertyNameInfo) {
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "Explicit";
+	}
+}

--- a/core/src/main/java/org/modelmapper/convention/MatchingStrategies.java
+++ b/core/src/main/java/org/modelmapper/convention/MatchingStrategies.java
@@ -65,4 +65,10 @@ public class MatchingStrategies {
    * </ul>
    */
   public static final MatchingStrategy STRICT = new StrictMatchingStrategy();
+    
+  /**
+   * A matching strategy that won't match automatically any properties. Only properties explicitly
+   * mapped will be copied to the destination.
+   */
+  public static final MatchingStrategy EXPLICIT = new ExplicitMatchingStrategy();
 }


### PR DESCRIPTION
I was starting to have almost as many "skips" in my code as "maps", so I decided to add a new "explicit" matching strategy that won't map any properties automatically. Feel free to name it differently or even discard it.
