### PR TITLE
Inherited shaded paths preventing customer converters from running

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
@@ -15,27 +15,17 @@
  */
 package org.modelmapper.internal;
 
-import java.lang.reflect.Constructor;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.modelmapper.Condition;
-import org.modelmapper.ConfigurationException;
-import org.modelmapper.Converter;
-import org.modelmapper.Provider;
-import org.modelmapper.TypeMap;
-import org.modelmapper.TypeToken;
+import org.modelmapper.*;
 import org.modelmapper.internal.converter.ConverterStore;
 import org.modelmapper.internal.util.Iterables;
 import org.modelmapper.internal.util.Primitives;
 import org.modelmapper.internal.util.Types;
-import org.modelmapper.spi.ConstantMapping;
-import org.modelmapper.spi.Mapping;
-import org.modelmapper.spi.MappingContext;
-import org.modelmapper.spi.MappingEngine;
-import org.modelmapper.spi.PropertyMapping;
-import org.modelmapper.spi.SourceMapping;
+import org.modelmapper.spi.*;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * MappingEngine implementation that caches ConditionalConverters by source and destination type
@@ -329,7 +319,7 @@ public class MappingEngineImpl implements MappingEngine {
 
     Class<Object> destinationType = (Class<Object>) mapping.getLastDestinationProperty().getType();
     return new MappingContextImpl(context, source, sourceType, null, destinationType, null,
-        mapping, !cyclic);
+        mapping, false);
   }
 
   /**


### PR DESCRIPTION
When creating a new property context, the shaded paths were being inherited. This meant that if you mapped two source classes to the same destination any custom converters defined in property maps for the second (or subsequent) mappings, would not be run. The functional test added, demonstrates this issue.

As a side note, even creating a copy of the destination class would exhibit the same problem.
