### PR TITLE
Introduced getType() to ValueReader interface

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/PropertyInfoSetResolver.java
+++ b/core/src/main/java/org/modelmapper/internal/PropertyInfoSetResolver.java
@@ -78,7 +78,16 @@ final class PropertyInfoSetResolver<T> {
       NameTransformer nameTransformer = configuration.getSourceNameTransformer();
       for (String memberName : valueReader.memberNames(source)) {
         Object sourceValue = valueReader.get(source, memberName);
-        if (sourceValue != null)
+        if (sourceValue == null) {
+          // Try to get value type from value reader
+          Class<?> sourceClass = valueReader.getType(source, memberName);
+          if (sourceClass != null)  {
+            accessors.put(nameTransformer.transform(memberName, NameableType.GENERIC),
+              new ValueReaderPropertyInfo(valueReader, sourceClass, memberName));
+          }
+        }
+        else
+          // Get value type from value
           accessors.put(nameTransformer.transform(memberName, NameableType.GENERIC),
               new ValueReaderPropertyInfo(valueReader, sourceValue, memberName));
       }

--- a/core/src/main/java/org/modelmapper/internal/valueaccess/MapValueReader.java
+++ b/core/src/main/java/org/modelmapper/internal/valueaccess/MapValueReader.java
@@ -35,4 +35,8 @@ public class MapValueReader implements ValueReader<Map<String, Object>> {
   public Collection<String> memberNames(Map<String, Object> source) {
     return source.keySet();
   }
+
+  public Class<?> getType(Map<String, Object> source, String memberName) {
+    return null;
+  }
 }

--- a/core/src/main/java/org/modelmapper/spi/ValueReader.java
+++ b/core/src/main/java/org/modelmapper/spi/ValueReader.java
@@ -36,4 +36,13 @@ public interface ValueReader<T> {
    * members.
    */
   Collection<String> memberNames(T source);
+
+  /**
+   * Returns the type from the {@code source} object for the {@code memberName}.   
+   * 
+   * @param source - source object
+   * @param memberName - source class member name
+   * @return type of source class member
+   */
+  Class<?> getType(T source, String memberName);
 }

--- a/extensions/gson/src/main/java/org/modelmapper/gson/JsonElementValueReader.java
+++ b/extensions/gson/src/main/java/org/modelmapper/gson/JsonElementValueReader.java
@@ -67,4 +67,14 @@ public class JsonElementValueReader implements ValueReader<JsonElement> {
   public String toString() {
     return "Gson";
   }
+
+  public Class<?> getType(JsonElement source, String memberName) {
+    if (source.isJsonObject()) {
+      JsonObject subjObj = source.getAsJsonObject();
+      JsonElement propertyElement = subjObj.get(memberName);
+      if (propertyElement == null) throw new IllegalArgumentException();
+        return propertyElement.getClass();
+    }
+    return null;
+  }
 }

--- a/extensions/jackson/src/main/java/org/modelmapper/jackson/JsonNodeValueReader.java
+++ b/extensions/jackson/src/main/java/org/modelmapper/jackson/JsonNodeValueReader.java
@@ -73,4 +73,23 @@ public class JsonNodeValueReader implements ValueReader<JsonNode> {
   public String toString() {
     return "Jackson";
   }
+
+  public Class<?> getType(JsonNode source, String memberName) {
+    JsonNode propertyNode = source.get(memberName);
+    if (propertyNode == null) throw new IllegalArgumentException();
+      switch (propertyNode.getNodeType()) {
+        case BOOLEAN:
+          return Boolean.class;
+        case NULL:
+          return null;
+        case NUMBER:
+          return Double.class;
+        case STRING:
+          return String.class;
+        case ARRAY:
+          return Collection.class;
+        default:
+          return Object.class;
+    }
+  }
 }

--- a/extensions/jooq/src/main/java/org/modelmapper/jooq/RecordValueReader.java
+++ b/extensions/jooq/src/main/java/org/modelmapper/jooq/RecordValueReader.java
@@ -57,4 +57,11 @@ public class RecordValueReader implements ValueReader<Record> {
   public String toString() {
     return "jOOQ";
   }
+
+  public Class<?> getType(Record source, String memberName) {
+    for (Field<?> field : source.fields())
+      if (memberName.equalsIgnoreCase(field.getName()))
+        return field.getType();
+    return null;
+  }
 }

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -20,6 +20,7 @@
     <module>jackson</module>
     <module>gson</module>
     <module>jooq</module>
+    <module>sql</module>
   </modules>
 
   <dependencies>

--- a/extensions/sql/pom.xml
+++ b/extensions/sql/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.modelmapper.extensions</groupId>
+    <artifactId>modelmapper-extensions</artifactId>
+    <version>0.7.8-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>modelmapper-sql</artifactId>
+  <name>ModelMapper SQL Extension</name>
+
+  <properties>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.9.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/extensions/sql/src/main/java/org/modelmapper/sql/ResultSetValueReader.java
+++ b/extensions/sql/src/main/java/org/modelmapper/sql/ResultSetValueReader.java
@@ -1,0 +1,68 @@
+package org.modelmapper.sql;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.modelmapper.spi.ValueReader;
+
+/**
+ * SQL ResultSet Value Reader Implementation 
+ * 
+ * @author Serge Matsevilo
+ *
+ */
+public class ResultSetValueReader implements ValueReader<ResultSet> {
+
+	public Object get(ResultSet source, String memberName) {
+		try {
+			return source.getObject(memberName);
+		} catch (SQLException e) {
+		      throw new IllegalArgumentException("Cannot get value for " + memberName, e);
+		}
+	}
+
+	public Class<?> getType(ResultSet source, String memberName) {
+		try {
+			ResultSetMetaData meta = source.getMetaData();
+			
+			for (int i = 1; i <= meta.getColumnCount(); i++) {
+				if (meta.getColumnName(i).equals(memberName)) {
+					try {
+						return Class.forName(meta.getColumnClassName(i));
+					} catch (ClassNotFoundException e) {
+					      throw new IllegalArgumentException("Cannot get class for " + memberName, e);
+					}
+				}
+			}
+		
+		} catch (SQLException e) {
+		      throw new IllegalArgumentException("Cannot get metadata for the specified result set.", e);
+		}
+
+		return Object.class;
+	}
+
+	public Collection<String> memberNames(ResultSet source) {
+		try {
+			ResultSetMetaData meta = source.getMetaData();
+			ArrayList<String> names = new ArrayList<String>(meta.getColumnCount());			
+			
+			for (int i = 1; i <= meta.getColumnCount(); i++) {
+				names.add(meta.getColumnName(i));
+			}
+			
+			return names;
+			
+		} catch (SQLException e) {
+		      throw new IllegalArgumentException("Cannot get columns from the spepecified result set.", e);
+		}
+	}
+	
+	  @Override
+	  public String toString() {
+	    return "SQL";
+	  }
+}

--- a/extensions/sql/src/test/java/org/modelmapper/sql/ResultSetValueReaderTest.java
+++ b/extensions/sql/src/test/java/org/modelmapper/sql/ResultSetValueReaderTest.java
@@ -1,0 +1,52 @@
+package org.modelmapper.sql;
+
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import org.mockito.Mockito;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.sql.ResultSetValueReader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test
+public class ResultSetValueReaderTest {
+	
+    static class Sample {
+        private String text;
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+    }
+
+    public void shouldCreateMapForNull() throws SQLException {
+        ModelMapper modelMapper = new ModelMapper();
+        modelMapper.getConfiguration().addValueReader(new ResultSetValueReader());
+
+        ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class); 
+        Mockito.when(meta.getColumnCount()).thenReturn(1);
+        Mockito.when(meta.getColumnName(1)).thenReturn("text");
+        Mockito.when(meta.getColumnClassName(1)).thenReturn(String.class.getName());
+
+        ResultSet set1 = Mockito.mock(ResultSet.class);
+        Mockito.when(set1.getMetaData()).thenReturn(meta);
+        Mockito.when(set1.getObject("text")).thenReturn(null);
+        
+        Sample obj1 = modelMapper.map(set1, Sample.class);
+        Assert.assertNull(obj1.getText());
+
+        ResultSet set2 = Mockito.mock(ResultSet.class);
+        Mockito.when(set2.getMetaData()).thenReturn(meta);
+        Mockito.when(set2.getObject("text")).thenReturn("abc");
+
+        Sample obj2 = modelMapper.map(set2, Sample.class);
+        Assert.assertEquals(obj2.getText(), "abc");
+    }
+}


### PR DESCRIPTION
Introduced getType() to ValueReader interface so that the concrete value readers can provide the type when value is null (see issue #168). 