### PR TITLE
Fix bug modelmapper skip path problem

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
@@ -160,8 +160,10 @@ public class MappingEngineImpl implements MappingEngine {
 
     if (condition != null) {
       if (!condition.applies(propertyContext)) {
-        context.shadePath(propertyPath);
-        return;
+        if (!mapping.isSkipped()) {
+          context.shadePath(propertyPath);
+          return;
+        }
       } else if (mapping.isSkipped())
         return;
     }

--- a/core/src/test/java/org/modelmapper/bugs/GH197.java
+++ b/core/src/test/java/org/modelmapper/bugs/GH197.java
@@ -1,0 +1,107 @@
+package org.modelmapper.bugs;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.Condition;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.PropertyMap;
+import org.modelmapper.spi.MappingContext;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * https://github.com/jhalterman/modelmapper/issues/197
+ */
+@Test
+public class GH197 extends AbstractTest {
+  public void shouldNotSkipWhenConditionNotMatch() {
+    Source source = new Source();
+    source.setId(15);
+    source.setName("Blablabla");
+
+
+    final Condition<Source, Destination> condition = new Condition<Source, Destination>() {
+      public boolean applies(MappingContext<Source, Destination> context) {
+        return false;
+      }
+    };
+
+    ModelMapper modelMapper = new ModelMapper();
+    modelMapper.addMappings(new PropertyMap<Source, Destination>() {
+      protected void configure() {
+        when(condition).skip().setName(source.getName());
+      }
+    });
+
+    Destination result = modelMapper.map(source, Destination.class);
+    assertEquals((int) result.getId(), 15);
+    assertEquals(result.getName(), "Blablabla");
+  }
+
+  public void shouldSkipWhenConditionMatch() {
+    Source source = new Source();
+    source.setId(15);
+    source.setName("Blablabla");
+
+
+    final Condition<Source, Destination> condition = new Condition<Source, Destination>() {
+      public boolean applies(MappingContext<Source, Destination> context) {
+        return true;
+      }
+    };
+
+    ModelMapper modelMapper = new ModelMapper();
+    modelMapper.addMappings(new PropertyMap<Source, Destination>() {
+      protected void configure() {
+        when(condition).skip().setName(source.getName());
+      }
+    });
+
+    Destination result = modelMapper.map(source, Destination.class);
+    assertEquals((int) result.getId(), 15);
+    assertNull(result.getName());
+  }
+
+  static class Destination {
+    private Integer id;
+    private String name;
+
+    public Integer getId() {
+      return id;
+    }
+
+    public void setId(Integer id) {
+      this.id = id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+  }
+
+  static class Source {
+    private int id;
+    private String name;
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+  }
+}


### PR DESCRIPTION
Ref: #197 

When used PropertyMap with ```when(condition).skip().setA(source.getA())```,
The field ```a``` will be skipped even condition not match.
That's not an expected behavior of modelmapper.

@AUsachov could you help me verify that the bug is fixed by this PR? Thanks!