### PR TITLE
Add PropertyMapProvider for explicit mapping inherit support

### DIFF
--- a/core/src/main/java/org/modelmapper/PropertyMapProvider.java
+++ b/core/src/main/java/org/modelmapper/PropertyMapProvider.java
@@ -1,0 +1,13 @@
+package org.modelmapper;
+
+/**
+ * Provides {@link PropertyMap} instances
+ *
+ * @param <PS> parent class or interface for source type
+ * @param <PD> parent class or interface for destination type
+ */
+public interface PropertyMapProvider<PS, PD> {
+
+  <S extends PS, D extends PD> PropertyMap<S, D> provide(
+      Class<S> sourceType, Class<D> destinationType);
+}

--- a/core/src/test/java/org/modelmapper/functional/inherit/ExplicitMapInheritTest.java
+++ b/core/src/test/java/org/modelmapper/functional/inherit/ExplicitMapInheritTest.java
@@ -1,0 +1,113 @@
+package org.modelmapper.functional.inherit;
+
+import org.modelmapper.AbstractProvider;
+import org.modelmapper.AbstractTest;
+import org.modelmapper.PropertyMap;
+import org.modelmapper.PropertyMapProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class ExplicitMapInheritTest extends AbstractTest {
+
+  interface SrcInterface {
+    String getSrc();
+  }
+
+  static class SrcA implements SrcInterface {
+    String src;
+
+    public SrcA(String src) {
+      this.src = src;
+    }
+
+    public String getSrc() {
+      return src;
+    }
+  }
+
+  static class SrcB implements SrcInterface {
+    String src;
+
+    public SrcB(String src) {
+      this.src = src;
+    }
+
+    public String getSrc() {
+      return src;
+    }
+  }
+
+  static class SrcC extends SrcB {
+    public SrcC(String src) {
+      super(src);
+    }
+  }
+
+  interface DestInterface {
+    void setDest(String dest);
+  }
+
+  static class DestA implements DestInterface {
+    String dest;
+
+    public void setDest(String dest) {
+      this.dest = dest;
+    }
+  }
+
+  static class DestB implements DestInterface {
+    String dest;
+
+    public void setDest(String dest) {
+      this.dest = dest;
+    }
+  }
+
+  static class DestC extends DestB {
+  }
+
+  static class MappingProvider implements PropertyMapProvider<SrcInterface, DestInterface> {
+    public <S extends SrcInterface, D extends DestInterface> PropertyMap<S, D> provide(Class<S> sourceType, Class<D> destinationType) {
+      return new PropertyMap<S, D>(sourceType, destinationType) {
+        @Override
+        protected void configure() {
+          map().setDest(source.getSrc());
+        }
+      };
+    }
+  }
+
+  public void shouldMappingClassSuccess() {
+    PropertyMapProvider<SrcInterface, DestInterface> provider = new MappingProvider();
+
+    modelMapper.addMappings(provider.provide(SrcA.class, DestA.class));
+    modelMapper.addMappings(provider.provide(SrcB.class, DestB.class));
+    modelMapper.addMappings(provider.provide(SrcC.class, DestC.class));
+
+    assertEquals(modelMapper.map(new SrcA("foo"), DestA.class).dest, "foo");
+    assertEquals(modelMapper.map(new SrcB("foo"), DestB.class).dest, "foo");
+    assertEquals(modelMapper.map(new SrcC("foo"), DestC.class).dest, "foo");
+
+    assertNull(modelMapper.map(new SrcA("foo"), DestB.class).dest);
+    assertNull(modelMapper.map(new SrcA("foo"), DestC.class).dest);
+    assertNull(modelMapper.map(new SrcC("foo"), DestB.class).dest);
+  }
+
+  public void shouldMappingInterfaceSuccess() {
+    PropertyMapProvider<SrcInterface, DestInterface> provider = new MappingProvider();
+
+    modelMapper.addMappings(provider.provide(SrcA.class, DestInterface.class)).setProvider(new AbstractProvider<DestInterface>() {
+      protected DestInterface get() {
+        return new DestA();
+      }
+    });
+
+    DestInterface dest = modelMapper.map(new SrcA("foo"), DestInterface.class);
+    assertTrue(dest instanceof DestA);
+    assertEquals(((DestA) dest).dest, "foo");
+  }
+}


### PR DESCRIPTION
Related: #13 #132 #170 #202 

### The Problem
Currently, we always failed when we try defined a PropertyMap that use interface as the source type.
Because modelmapper always use the actual type of source to search for the match TypeMap and it will failed to find our PropertyMap.

### Potential Solution
There might be two solutions.
I think both had its advantage and disadvantage.
So I would hear anyone's advise that had similar problem.

#### Solution A
Add new methods on ModelMapper::map that can explicit pass source type and destination type as the arguments.
Some people had suggest it ( [#13](https://github.com/modelmapper/modelmapper/issues/13#issuecomment-140867744), #132 ) and had a PR ( #160 ) for it.

#### Solution B
Provide a nice api so that we can config multiple subclass with one same PropertyMap
(That's this PR about)


### This PR still work in progress
#### - Nicely documentation
#### - More friendly API
```java
// For example
PropertyMapConfig
  .withPropertyMapProvider(propertyMapProvider)
  .withDestinationProvider(provider)
  .with(srcTypeA, destTypeA)
  .with(srcTypeB, destTypeB)
  .with(srcTypeC, destTypeC)
  .config(modelMapper); // Will call modelMapper.addMappings multiple times
```