### PR TITLE
TypeMap inheritance

### DIFF
--- a/core/src/main/java/org/modelmapper/TypeMap.java
+++ b/core/src/main/java/org/modelmapper/TypeMap.java
@@ -276,4 +276,32 @@ public interface TypeMap<S, D> {
    * @return this typeMap
    */
   TypeMap<S, D> addMappings(ExpressionMap<S, D> mapper);
+
+  /**
+   * Constructs a new TypeMap derived from {@code this}. The derived TypeMap will includes
+   * all {@code mappings} from the base {@link TypeMap}, but will NOT include {@code converter},
+   * {@code condition}, and {@code provider} from the base {@link TypeMap}.
+   *
+   * @param sourceType source type
+   * @param destinationType destination type
+   * @param <DS> derived type of source class
+   * @param <DD> derived type of destination class
+   * @return this type map
+   *
+   * @throws IllegalArgumentException if {@code TypePair.of(sourceType, destinationType)} already defined
+   *         in {@code modelMapper.getTypeMaps()}
+   */
+  <DS extends S, DD extends D> TypeMap<S, D> include(Class<DS> sourceType, Class<DD> destinationType);
+
+  /**
+   * Includes {@code mappings} from a base {@link TypeMap}.
+   *
+   * @param sourceType source type
+   * @param destinationType destination type
+   * @return this type map
+   *
+   * @throws IllegalArgumentException if {@code TypePair.of(sourceType, destinationType)} already defined
+   *         in {@code modelMapper.getTypeMaps()}
+   */
+  TypeMap<S, D> includeBase(Class<? super S> sourceType, Class<? super D> destinationType);
 }

--- a/core/src/main/java/org/modelmapper/internal/TypeMapStore.java
+++ b/core/src/main/java/org/modelmapper/internal/TypeMapStore.java
@@ -132,4 +132,21 @@ public final class TypeMapStore {
       return typeMap;
     }
   }
+
+  /**
+   * Puts a typeMap into store
+   *
+   * @throws IllegalArgumentException if {@link TypePair} of typeMap is already exists in the store
+   */
+  public void put(TypeMap<?, ?> typeMap) {
+    TypePair<?, ?> typePair = TypePair.of(typeMap.getSourceType(),
+        typeMap.getDestinationType(), typeMap.getName());
+
+    synchronized (lock) {
+      if (typeMaps.containsKey(typePair)) {
+        throw new IllegalArgumentException("TypeMap exists in the store: " + typePair.toString());
+      }
+      typeMaps.put(typePair, typeMap);
+    }
+  }
 }

--- a/core/src/test/java/org/modelmapper/functional/inherit/MultipleInterfacesTest.java
+++ b/core/src/test/java/org/modelmapper/functional/inherit/MultipleInterfacesTest.java
@@ -1,0 +1,105 @@
+package org.modelmapper.functional.inherit;
+
+import static org.testng.Assert.assertEquals;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.PropertyMap;
+import org.testng.annotations.Test;
+
+@Test
+public class MultipleInterfacesTest extends AbstractTest {
+
+  interface InterfaceA {
+    String getA();
+
+    void setA(String a);
+  }
+
+  interface InterfaceB {
+    String getB();
+
+    void setB(String b);
+  }
+
+  interface InterfaceC {
+    String getC();
+
+    void setC(String c);
+  }
+
+  interface InterfaceD {
+    String getD();
+
+    void setD(String d);
+  }
+
+  static class Source implements InterfaceA, InterfaceB {
+    String a;
+    String b;
+
+    public Source(String a, String b) {
+      this.a = a;
+      this.b = b;
+    }
+
+    public String getA() {
+      return a;
+    }
+
+    public void setA(String a) {
+      this.a = a;
+    }
+
+    public String getB() {
+      return b;
+    }
+
+    public void setB(String b) {
+      this.b = b;
+    }
+  }
+
+  static class Destination implements InterfaceC, InterfaceD {
+    String c;
+    String d;
+
+    public String getC() {
+      return c;
+    }
+
+    public void setC(String c) {
+      this.c = c;
+    }
+
+    public String getD() {
+      return d;
+    }
+
+    public void setD(String d) {
+      this.d = d;
+    }
+  }
+
+  public void shouldIncludeBaseTypeMaps() {
+    modelMapper.addMappings(new PropertyMap<InterfaceA, InterfaceC>() {
+      @Override
+      protected void configure() {
+        map().setC(source.getA());
+      }
+    });
+    modelMapper.addMappings(new PropertyMap<InterfaceB, InterfaceD>() {
+      @Override
+      protected void configure() {
+        map().setD(source.getB());
+      }
+    });
+
+    modelMapper.createTypeMap(Source.class, Destination.class)
+        .includeBase(InterfaceA.class, InterfaceC.class)
+        .includeBase(InterfaceB.class, InterfaceD.class);
+
+    Destination destination = modelMapper.map(new Source("foo", "bar"), Destination.class);
+    assertEquals(destination.getC(), "foo");
+    assertEquals(destination.getD(), "bar");
+  }
+}

--- a/core/src/test/java/org/modelmapper/functional/inherit/TypeMapIncludeBaseTest.java
+++ b/core/src/test/java/org/modelmapper/functional/inherit/TypeMapIncludeBaseTest.java
@@ -1,0 +1,113 @@
+package org.modelmapper.functional.inherit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.PropertyMap;
+import org.modelmapper.Provider;
+import org.testng.annotations.Test;
+
+@Test
+public class TypeMapIncludeBaseTest extends AbstractTest {
+
+  interface SrcInterface {
+    String getSrc();
+  }
+
+  static class SrcA implements SrcInterface {
+    String src;
+
+    public SrcA(String src) {
+      this.src = src;
+    }
+
+    public String getSrc() {
+      return src;
+    }
+  }
+
+  static class SrcB implements SrcInterface {
+    String src;
+
+    public SrcB(String src) {
+      this.src = src;
+    }
+
+    public String getSrc() {
+      return src;
+    }
+  }
+
+  static class SrcC extends SrcB {
+    public SrcC(String src) {
+      super(src);
+    }
+  }
+
+  interface DestInterface {
+    void setDest(String dest);
+  }
+
+  static class DestA implements DestInterface {
+    String dest;
+
+    public void setDest(String dest) {
+      this.dest = dest;
+    }
+  }
+
+  static class DestB implements DestInterface {
+    String dest;
+
+    public void setDest(String dest) {
+      this.dest = dest;
+    }
+  }
+
+  static class DestC extends DestB {
+  }
+
+  public void shouldMappingClassSuccess() {
+    modelMapper.addMappings(new PropertyMap<SrcInterface, DestInterface>() {
+          @Override
+          protected void configure() {
+            map().setDest(source.getSrc());
+          }
+        });
+
+    modelMapper.createTypeMap(SrcA.class, DestA.class).includeBase(SrcInterface.class, DestInterface.class);
+    modelMapper.createTypeMap(SrcB.class, DestB.class).includeBase(SrcInterface.class, DestInterface.class);
+    modelMapper.createTypeMap(SrcC.class, DestC.class).includeBase(SrcInterface.class, DestInterface.class);
+
+    assertEquals(modelMapper.map(new SrcA("foo"), DestA.class).dest, "foo");
+    assertEquals(modelMapper.map(new SrcB("foo"), DestB.class).dest, "foo");
+    assertEquals(modelMapper.map(new SrcC("foo"), DestC.class).dest, "foo");
+
+    assertNull(modelMapper.map(new SrcA("foo"), DestB.class).dest);
+    assertNull(modelMapper.map(new SrcA("foo"), DestC.class).dest);
+    assertNull(modelMapper.map(new SrcC("foo"), DestB.class).dest);
+  }
+
+  public void shouldMappingInterfaceSuccess() {
+    modelMapper.addMappings(new PropertyMap<SrcInterface, DestInterface>() {
+          @Override
+          protected void configure() {
+            map().setDest(source.getSrc());
+          }
+        });
+
+    modelMapper.createTypeMap(SrcA.class, DestInterface.class)
+        .includeBase(SrcInterface.class, DestInterface.class)
+        .setProvider(new Provider<DestInterface>() {
+          public DestInterface get(ProvisionRequest<DestInterface> request) {
+            return new DestA();
+          }
+    });
+
+    DestInterface dest = modelMapper.map(new SrcA("foo"), DestInterface.class);
+    assertTrue(dest instanceof DestA);
+    assertEquals(((DestA) dest).dest, "foo");
+  }
+}

--- a/core/src/test/java/org/modelmapper/functional/inherit/TypeMapIncludeTest.java
+++ b/core/src/test/java/org/modelmapper/functional/inherit/TypeMapIncludeTest.java
@@ -1,0 +1,188 @@
+package org.modelmapper.functional.inherit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import org.modelmapper.*;
+import org.testng.annotations.Test;
+
+@Test
+public class TypeMapIncludeTest extends AbstractTest {
+
+  interface SrcInterface {
+    String getSrc();
+  }
+
+  static class SrcA implements SrcInterface {
+    String src;
+
+    public SrcA(String src) {
+      this.src = src;
+    }
+
+    public String getSrc() {
+      return src;
+    }
+  }
+
+  static class SrcB implements SrcInterface {
+    String src;
+
+    public SrcB(String src) {
+      this.src = src;
+    }
+
+    public String getSrc() {
+      return src;
+    }
+  }
+
+  static class SrcC extends SrcB {
+    public SrcC(String src) {
+      super(src);
+    }
+  }
+
+  interface DestInterface {
+    String getDest();
+    void setDest(String dest);
+  }
+
+  static class DestA implements DestInterface {
+    String dest;
+
+    public String getDest() {
+      return dest;
+    }
+
+    public void setDest(String dest) {
+      this.dest = dest;
+    }
+  }
+
+  static class DestB implements DestInterface {
+    String dest;
+
+    public String getDest() {
+      return dest;
+    }
+
+    public void setDest(String dest) {
+      this.dest = dest;
+    }
+  }
+
+  static class DestC extends DestB {
+  }
+
+  static class BasePropertyMap extends PropertyMap<SrcInterface, DestInterface> {
+    @Override
+    protected void configure() {
+      map().setDest(source.getSrc());
+    }
+  }
+
+  public void shouldMappingClassSuccess() {
+    TypeMap<SrcInterface, DestInterface> baseTypeMap = modelMapper.addMappings(new BasePropertyMap());
+
+    baseTypeMap
+        .include(SrcA.class, DestA.class)
+        .include(SrcB.class, DestB.class)
+        .include(SrcC.class, DestC.class);
+
+    assertEquals(modelMapper.map(new SrcA("foo"), DestA.class).dest, "foo");
+    assertEquals(modelMapper.map(new SrcB("foo"), DestB.class).dest, "foo");
+    assertEquals(modelMapper.map(new SrcC("foo"), DestC.class).dest, "foo");
+
+    assertNull(modelMapper.map(new SrcA("foo"), DestB.class).dest);
+    assertNull(modelMapper.map(new SrcA("foo"), DestC.class).dest);
+    assertNull(modelMapper.map(new SrcC("foo"), DestB.class).dest);
+  }
+
+  public void shouldNotMappingUndefinedTypeMap() {
+    TypeMap<SrcInterface, DestInterface> baseTypeMap = modelMapper.addMappings(new BasePropertyMap());
+
+    baseTypeMap
+        .include(SrcA.class, DestA.class)
+        .include(SrcB.class, DestB.class)
+        .include(SrcC.class, DestC.class);
+
+    assertNull(modelMapper.map(new SrcA("foo"), DestB.class).dest);
+    assertNull(modelMapper.map(new SrcA("foo"), DestC.class).dest);
+    assertNull(modelMapper.map(new SrcC("foo"), DestB.class).dest);
+  }
+
+  public void shouldMappingInterfaceWithProviderSuccess() {
+    TypeMap<SrcInterface, DestInterface> baseTypeMap = modelMapper.addMappings(new BasePropertyMap());
+
+    baseTypeMap
+        .include(SrcA.class, DestInterface.class)
+        .include(SrcB.class, DestInterface.class)
+        .include(SrcC.class, DestInterface.class);
+
+    modelMapper.getTypeMap(SrcA.class, DestInterface.class).setProvider(new Provider<DestInterface>() {
+      public DestInterface get(ProvisionRequest<DestInterface> request) {
+        return new DestA();
+      }
+    });
+
+    modelMapper.getTypeMap(SrcB.class, DestInterface.class).setProvider(new Provider<DestInterface>() {
+      public DestInterface get(ProvisionRequest<DestInterface> request) {
+        return new DestB();
+      }
+    });
+
+    modelMapper.getTypeMap(SrcC.class, DestInterface.class).setProvider(new Provider<DestInterface>() {
+      public DestInterface get(ProvisionRequest<DestInterface> request) {
+        return new DestC();
+      }
+    });
+
+    DestInterface destA = modelMapper.map(new SrcA("foo"), DestInterface.class);
+    assertTrue(destA instanceof DestA);
+    assertEquals(destA.getDest(), "foo");
+
+    DestInterface destB = modelMapper.map(new SrcB("foo"), DestInterface.class);
+    assertTrue(destB instanceof DestB);
+    assertEquals(destB.getDest(), "foo");
+
+    DestInterface destC = modelMapper.map(new SrcC("foo"), DestInterface.class);
+    assertTrue(destC instanceof DestC);
+    assertEquals(destC.getDest(), "foo");
+  }
+
+  public void shouldFailedDuplicateInclude() {
+    TypeMap<SrcInterface, DestInterface> baseTypeMap = modelMapper.addMappings(new BasePropertyMap());
+
+    baseTypeMap.include(SrcA.class, DestA.class);
+    try {
+      baseTypeMap.include(SrcA.class, DestA.class);
+    } catch (IllegalArgumentException e) {
+      Asserts.assertContains(e.getMessage(), "TypeMap exists in the store");
+    }
+  }
+
+  public void shouldMapDependsOnDestType() {
+    TypeMap<SrcInterface, DestInterface> baseTypeMap = modelMapper.addMappings(new BasePropertyMap());
+
+    baseTypeMap
+        .include(SrcA.class, DestA.class)
+        .include(SrcA.class, DestC.class)
+        .include(SrcA.class, DestInterface.class);
+
+    modelMapper.getTypeMap(SrcA.class, DestInterface.class).setProvider(new AbstractProvider<DestInterface>() {
+      @Override
+      protected DestInterface get() {
+        return new DestA();
+      }
+    });
+
+    assertEquals(modelMapper.map(new SrcA("foo"), DestA.class).dest, "foo");
+    assertEquals(modelMapper.map(new SrcA("foo"), DestC.class).dest, "foo");
+    assertTrue(modelMapper.map(new SrcA("foo"), DestInterface.class) instanceof DestA);
+
+    assertNull(modelMapper.map(new SrcA("foo"), DestB.class).dest);
+  }
+}

--- a/core/src/test/java/org/modelmapper/functional/inherit/TypeMapInheritanceDeepTypeTest.java
+++ b/core/src/test/java/org/modelmapper/functional/inherit/TypeMapInheritanceDeepTypeTest.java
@@ -1,0 +1,115 @@
+package org.modelmapper.functional.inherit;
+
+import static org.testng.Assert.assertEquals;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.PropertyMap;
+import org.modelmapper.Provider;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test
+public class TypeMapInheritanceDeepTypeTest extends AbstractTest {
+
+  interface SrcParent {
+    SrcChild getChild();
+  }
+
+  interface SrcChild {
+    String getOwnerId();
+  }
+
+  static class SrcParentImpl implements SrcParent {
+    private SrcChild child;
+
+    public SrcParentImpl(SrcChild child) {
+      this.child = child;
+    }
+
+    public SrcChild getChild() {
+      return child;
+    }
+  }
+
+  static class SrcChildImpl implements SrcChild {
+    private String ownerId;
+
+    public SrcChildImpl(String ownerId) {
+      this.ownerId = ownerId;
+    }
+
+    public String getOwnerId() {
+      return ownerId;
+    }
+  }
+
+  interface DestParent {
+    DestChild getChild();
+    void setChild(DestChild child);
+  }
+
+  interface DestChild {
+    String getOwnerId();
+    void setOwnerId(String ownerId);
+  }
+
+  static class DestParentImpl implements DestParent {
+    private DestChild child;
+
+    public DestChild getChild() {
+      return child;
+    }
+
+    public void setChild(DestChild child) {
+      this.child = child;
+    }
+  }
+
+  static class DestChildImpl implements DestChild {
+    private String ownerId;
+
+    public String getOwnerId() {
+      return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+      this.ownerId = ownerId;
+    }
+  }
+
+  static class ParentPropertyMap extends PropertyMap<SrcParent, DestParent> {
+    @Override
+    protected void configure() {
+      with(new Provider<Object>() {
+        public Object get(ProvisionRequest<Object> request) {
+          return new DestChildImpl();
+        }
+      }).map(source.getChild()).setChild(null);
+    }
+  }
+
+  static class ChildPropertyMap extends PropertyMap<SrcChild, DestChild> {
+    @Override
+    protected void configure() {
+      map().setOwnerId(source.getOwnerId());
+    }
+  }
+
+  @BeforeMethod
+  public void setUp() {
+    modelMapper.getConfiguration().setImplicitMappingEnabled(false);
+  }
+
+  @Test
+  public void shouldMapIfInclude() throws Exception {
+    modelMapper.addMappings(new ParentPropertyMap())
+        .include(SrcParentImpl.class, DestParentImpl.class);
+
+    modelMapper.addMappings(new ChildPropertyMap())
+        .include(SrcChildImpl.class, DestChild.class);
+
+    SrcParent src = new SrcParentImpl(new SrcChildImpl("foo"));
+    DestParentImpl dest = modelMapper.map(src, DestParentImpl.class);
+    assertEquals(dest.getChild().getOwnerId(), "foo");
+  }
+}

--- a/core/src/test/java/org/modelmapper/functional/inherit/ValueReaderInheritanceTest.java
+++ b/core/src/test/java/org/modelmapper/functional/inherit/ValueReaderInheritanceTest.java
@@ -1,0 +1,78 @@
+package org.modelmapper.functional.inherit;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.PropertyMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+@Test
+public class ValueReaderInheritanceTest extends AbstractTest {
+  static class Dest {
+    private String name;
+    private String address;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getAddress() {
+      return address;
+    }
+
+    public void setAddress(String address) {
+      this.address = address;
+    }
+  }
+
+  @BeforeMethod
+  public void setUp() {
+    modelMapper.getConfiguration().setImplicitMappingEnabled(false);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldInclude() throws Exception {
+    modelMapper.addMappings(new PropertyMap<Map<String, Object>, Dest>() {
+      @Override
+      protected void configure() {
+        map(source("name")).setName(null);
+        map(source("address")).setAddress(null);
+      }
+    }).include(HashMap.class, Dest.class);
+
+    Map<String, Object> src = new HashMap<String, Object>();
+    src.put("name", "foo");
+    src.put("address", "bar");
+    Dest dest = modelMapper.map(src, Dest.class);
+
+    assertEquals(dest.name, "foo");
+    assertEquals(dest.address, "bar");
+  }
+
+  public void shouldNotMapIfNotInclude() throws Exception {
+    modelMapper.addMappings(new PropertyMap<Map<String, Object>, Dest>() {
+      @Override
+      protected void configure() {
+        map(source("name")).setName(null);
+        map(source("address")).setAddress(null);
+      }
+    });
+
+    Map<String, Object> src = new HashMap<String, Object>();
+    src.put("name", "foo");
+    src.put("address", "bar");
+    Dest dest = modelMapper.map(src, Dest.class);
+
+    assertNull(dest.name);
+    assertNull(dest.address);
+  }
+}


### PR DESCRIPTION
Related: #13 #130 #132 #170 #202 

A better solution than #208

After that, TypeMap provide ```include``` and ```includeBase``` for inheritance

#### TypeMap::include example
```
    TypeMap<SrcInterface, DestInterface> baseTypeMap =
        modelMapper.addMappings(new PropertyMap<SrcInterface, DestInterface>() {
          @Override
          protected void configure() {
            map().setDest(source.getSrc());
          }
        });
    baseTypeMap.include(SrcA.class, DestA.class)
           .include(SrcB.class, DestB.class);
           .include(SrcC.class, DestC.class);
```

#### TypeMap::includeBase example
```
    modelMapper.addMappings(new PropertyMap<SrcInterface, DestInterface>() {
          @Override
          protected void configure() {
            map().setDest(source.getSrc());
          }
        });

    modelMapper.createTypeMap(SrcA.class, DestA.class).includeBase(SrcInterface.class, DestInterface.class);
    modelMapper.createTypeMap(SrcB.class, DestB.class).includeBase(SrcInterface.class, DestInterface.class);
    modelMapper.createTypeMap(SrcC.class, DestC.class).includeBase(SrcInterface.class, DestInterface.class);
```

#### Restriction
The ```include``` and ```includeBase``` will inherit from base/derived TypeMap with following
- name
- configuration

Will not inherit from base/derived TypeMap with following
- converter
- condition
- provider


#### TODO
- Nice documentation
- Waiting for discussion about the solution
- More unit test