### PR TITLE
Resolved ValueReader handling null value problem

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/Accessor.java
+++ b/core/src/main/java/org/modelmapper/internal/Accessor.java
@@ -15,13 +15,11 @@
  */
 package org.modelmapper.internal;
 
-import org.modelmapper.spi.PropertyInfo;
-
 /**
  * An accessor that encapsulates a property.
  * 
  * @author Jonathan Halterman
  */
-interface Accessor extends PropertyInfo {
+interface Accessor extends InternalPropertyInfo {
   Object getValue(Object subject);
 }

--- a/core/src/main/java/org/modelmapper/internal/InternalPropertyInfo.java
+++ b/core/src/main/java/org/modelmapper/internal/InternalPropertyInfo.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.internal;
+
+import org.modelmapper.spi.PropertyInfo;
+
+/**
+ * Encapsulates information for a property only be used internally.
+ *
+ * @author Chun Han Hsiao
+ */
+public interface InternalPropertyInfo extends PropertyInfo {
+  TypeInfo<?> getTypeInfo(InheritingConfiguration configuration);
+}

--- a/core/src/main/java/org/modelmapper/internal/Mutator.java
+++ b/core/src/main/java/org/modelmapper/internal/Mutator.java
@@ -15,13 +15,11 @@
  */
 package org.modelmapper.internal;
 
-import org.modelmapper.spi.PropertyInfo;
-
 /**
  * A mutator that encapsulates a property.
  * 
  * @author Jonathan Halterman
  */
-interface Mutator extends PropertyInfo {
+interface Mutator extends InternalPropertyInfo {
   void setValue(Object subject, Object value);
 }

--- a/core/src/main/java/org/modelmapper/internal/PropertyInfoSetResolver.java
+++ b/core/src/main/java/org/modelmapper/internal/PropertyInfoSetResolver.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import org.modelmapper.config.Configuration;
 import org.modelmapper.config.Configuration.AccessLevel;
-import org.modelmapper.internal.PropertyInfoImpl.ValueReaderPropertyInfo;
 import org.modelmapper.spi.NameTransformer;
 import org.modelmapper.spi.NameableType;
 import org.modelmapper.spi.NamingConvention;
@@ -77,10 +76,10 @@ final class PropertyInfoSetResolver<T> {
     else {
       NameTransformer nameTransformer = configuration.getSourceNameTransformer();
       for (String memberName : valueReader.memberNames(source)) {
-        Object sourceValue = valueReader.get(source, memberName);
-        if (sourceValue != null)
+        ValueReader.Member<?> member = valueReader.getMember(source, memberName);
+        if (member != null)
           accessors.put(nameTransformer.transform(memberName, NameableType.GENERIC),
-              new ValueReaderPropertyInfo(valueReader, sourceValue, memberName));
+              PropertyInfoImpl.ValueReaderPropertyInfo.fromMember(member, memberName));
       }
     }
     return accessors;

--- a/core/src/main/java/org/modelmapper/internal/TypeInfoRegistry.java
+++ b/core/src/main/java/org/modelmapper/internal/TypeInfoRegistry.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.modelmapper.config.Configuration;
-import org.modelmapper.internal.PropertyInfoImpl.ValueReaderPropertyInfo;
 
 /**
  * Statically stores and retrieves TypeInfo instances by type, parent type, and configuration.
@@ -57,9 +56,7 @@ class TypeInfoRegistry {
 
   @SuppressWarnings("unchecked")
   static <T> TypeInfoImpl<T> typeInfoFor(Accessor accessor, InheritingConfiguration configuration) {
-    return (TypeInfoImpl<T>) TypeInfoRegistry.typeInfoFor(
-        (T) (accessor instanceof ValueReaderPropertyInfo ? ((ValueReaderPropertyInfo) accessor).source
-            : null), (Class<T>) accessor.getType(), configuration);
+    return TypeInfoRegistry.typeInfoFor(null, (Class<T>) accessor.getType(), configuration);
   }
 
   /**

--- a/core/src/main/java/org/modelmapper/internal/util/Types.java
+++ b/core/src/main/java/org/modelmapper/internal/util/Types.java
@@ -26,6 +26,8 @@ import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.Calendar;
+import java.util.Date;
 
 /**
  * Utilities for working with types.
@@ -146,5 +148,18 @@ public final class Types {
    */
   public static String toString(Type type) {
     return type instanceof Class ? ((Class<?>) type).getName() : type.toString();
+  }
+
+  /**
+   * Returns whether the type might contains properties or not.
+   */
+  public static boolean mightContainsProperties(Class<?> type) {
+    return type != Object.class
+        && type != String.class
+        && type != Date.class
+        && type != Calendar.class
+        && !Primitives.isPrimitive(type)
+        && !Iterables.isIterable(type)
+        && !Types.isGroovyType(type);
   }
 }

--- a/core/src/main/java/org/modelmapper/internal/valueaccess/MapValueReader.java
+++ b/core/src/main/java/org/modelmapper/internal/valueaccess/MapValueReader.java
@@ -32,7 +32,22 @@ public class MapValueReader implements ValueReader<Map<String, Object>> {
     return source.get(memberName);
   }
 
+  @SuppressWarnings("unchecked")
+  public Member<Map<String, Object>> getMember(Map<String, Object> source, String memberName) {
+    final Object value = get(source, memberName);
+
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Map) {
+      return new Member<Map<String, Object>>(this, Map.class, (Map<String, Object>) value);
+    }
+
+    return new Member<Map<String, Object>>(this, value.getClass());
+  }
+
   public Collection<String> memberNames(Map<String, Object> source) {
     return source.keySet();
   }
+
 }

--- a/core/src/main/java/org/modelmapper/spi/ValueReader.java
+++ b/core/src/main/java/org/modelmapper/spi/ValueReader.java
@@ -32,8 +32,64 @@ public interface ValueReader<T> {
   Object get(T source, String memberName);
 
   /**
+   * Returns the {@link Member} from the {@code source} within given {@code memberName}.
+   *
+   * @param source the source object
+   * @param memberName the name of member
+   */
+  Member<T> getMember(T source, String memberName);
+
+  /**
    * Returns all member names for the {@code source} object, else {@code null} if the source has no
    * members.
    */
   Collection<String> memberNames(T source);
+
+
+  /**
+   * A member of a given source
+   *
+   * @param <T> source type
+   */
+  class Member<T> {
+    private ValueReader<T> valueReader;
+    private Class<Object> valueType;
+    private T nestedValue;
+
+    /**
+     * Creates a member doesn't contain nested value
+     *
+     * @param valueReader the ValueReader itself
+     * @param valueType the value type
+     */
+    public Member(ValueReader<T> valueReader, Class<?> valueType) {
+      this(valueReader, valueType, null);
+    }
+
+    /**
+     * Creates a member contains nested value
+     *
+     * @param valueReader the ValueReader itself
+     * @param valueType the value type
+     * @param nestedValue the nested value
+     */
+    @SuppressWarnings("unchecked")
+    public Member(ValueReader<T> valueReader, Class<?> valueType, T nestedValue) {
+      this.valueReader = valueReader;
+      this.valueType = (Class<Object>) valueType;
+      this.nestedValue = nestedValue;
+    }
+
+    public ValueReader<T> getValueReader() {
+      return valueReader;
+    }
+
+    public Class<Object> getValueType() {
+      return valueType;
+    }
+
+    public T getNestedValue() {
+      return nestedValue;
+    }
+  }
 }

--- a/core/src/test/java/org/modelmapper/TypeMapTest.java
+++ b/core/src/test/java/org/modelmapper/TypeMapTest.java
@@ -3,6 +3,8 @@ package org.modelmapper;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -53,11 +55,17 @@ public class TypeMapTest extends AbstractTest {
     List<PropertyInfo> memberInfo = personMap.getUnmappedProperties();
     assertEquals(memberInfo.size(), 2);
 
-    PropertyInfo surName = memberInfo.get(0);
-    assertEquals(surName.getMember().getName(), "setSurName");
+    Collections.sort(memberInfo, new Comparator<PropertyInfo>() {
+      public int compare(PropertyInfo o1, PropertyInfo o2) {
+        return o1.getName().compareTo(o2.getName());
+      }
+    });
 
-    PropertyInfo employerName = memberInfo.get(1);
+    PropertyInfo employerName = memberInfo.get(0);
     assertEquals(employerName.getMember().getName(), "setEmployerName");
+
+    PropertyInfo surName = memberInfo.get(1);
+    assertEquals(surName.getMember().getName(), "setSurName");
   }
 
   public void shouldMergeMappings() {

--- a/core/src/test/java/org/modelmapper/functional/deepmapping/DeepMappingTest1.java
+++ b/core/src/test/java/org/modelmapper/functional/deepmapping/DeepMappingTest1.java
@@ -71,10 +71,10 @@ public class DeepMappingTest1 extends AbstractTest {
   }
 
   static class D2 {
-    String value;
+    String dest;
 
-    public void setDest(String value) {
-      this.value = value;
+    public void setDest(String dest) {
+      this.dest = dest;
     }
   }
 
@@ -111,6 +111,6 @@ public class DeepMappingTest1 extends AbstractTest {
     A2 a2 = modelMapper.map(a1, A2.class);
 
     modelMapper.validate();
-    assertEquals(a2.bb.cc.dd.value, "src");
+    assertEquals(a2.bb.cc.dd.dest, "src");
   }
 }

--- a/core/src/test/java/org/modelmapper/functional/deepmapping/NestedMappingTest2.java
+++ b/core/src/test/java/org/modelmapper/functional/deepmapping/NestedMappingTest2.java
@@ -278,7 +278,9 @@ public class NestedMappingTest2 extends AbstractTest {
 
     Event3 event3 = modelMapper.map(dto, Event3.class);
 
-    modelMapper.validate();
+    // The typeMap is not full match
+    // modelMapper.validate();
+
     assertEquals(dto.firstYear, event3.firstEvent.year);
     assertEquals(event3.firstEvent.date, 0);
     assertEquals(event3.firstEvent.month, 0);

--- a/core/src/test/java/org/modelmapper/internal/MatchingStrategyTestSupport.java
+++ b/core/src/test/java/org/modelmapper/internal/MatchingStrategyTestSupport.java
@@ -185,5 +185,9 @@ public class MatchingStrategyTestSupport {
     public Class<?> getInitialType() {
       return null;
     }
+
+    public TypeInfo<?> getTypeInfo(InheritingConfiguration configuration) {
+      return TypeInfoRegistry.typeInfoFor(memberClass, configuration);
+    }
   }
 }

--- a/core/src/test/java/org/modelmapper/internal/valueaccess/MapValueReaderTest.java
+++ b/core/src/test/java/org/modelmapper/internal/valueaccess/MapValueReaderTest.java
@@ -1,6 +1,8 @@
 package org.modelmapper.internal.valueaccess;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -93,5 +95,30 @@ public class MapValueReaderTest extends AbstractTest {
     modelMapper.validate();
     assertEquals(map.get("customer").get("address").get("city"), order.customer.address.city);
     assertEquals(map.get("customer").get("address").get("street"), order.customer.address.street);
+  }
+
+  public void shouldMapNullValue() {
+    Map<String, Object> addressMap1 = new HashMap<String, Object>();
+    addressMap1.put("street", "Street A");
+    addressMap1.put("city", null);
+
+    Map<String, Object> addressMap2 = new HashMap<String, Object>();
+    addressMap2.put("street", "Street B");
+    addressMap2.put("city", "City");
+
+    Map<String, Object> addressMap3 = new HashMap<String, Object>();
+    addressMap3.put("street", "Street C");
+    addressMap3.put("city", "City II");
+
+    Address address1 = modelMapper.map(addressMap1, Address.class);
+    Address address2 = modelMapper.map(addressMap2, Address.class);
+    Address address3 = modelMapper.map(addressMap3, Address.class);
+
+    assertEquals(address1.street, "Street A");
+    assertNull(address1.city);
+    assertEquals(address2.street, "Street B");
+    assertEquals(address2.city, "City");
+    assertEquals(address3.street, "Street C");
+    assertEquals(address3.city, "City II");
   }
 }

--- a/extensions/gson/src/main/java/org/modelmapper/gson/JsonElementValueReader.java
+++ b/extensions/gson/src/main/java/org/modelmapper/gson/JsonElementValueReader.java
@@ -56,6 +56,18 @@ public class JsonElementValueReader implements ValueReader<JsonElement> {
     return null;
   }
 
+  public Member<JsonElement> getMember(JsonElement source, String memberName) {
+    final Object value = get(source, memberName);
+    if (value == null)
+      return null;
+
+    if (value instanceof JsonElement) {
+      return new Member<JsonElement>(this, JsonElement.class, (JsonElement) value);
+    }
+
+    return new Member<JsonElement>(this, value.getClass());
+  }
+
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public Collection<String> memberNames(JsonElement source) {
     if (source.isJsonObject())

--- a/extensions/jackson/src/main/java/org/modelmapper/jackson/JsonNodeValueReader.java
+++ b/extensions/jackson/src/main/java/org/modelmapper/jackson/JsonNodeValueReader.java
@@ -22,8 +22,6 @@ import org.modelmapper.internal.util.Lists;
 import org.modelmapper.spi.ValueReader;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NumericNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.POJONode;
 
 /**
@@ -43,7 +41,7 @@ public class JsonNodeValueReader implements ValueReader<JsonNode> {
       case NULL:
         return null;
       case NUMBER:
-        return ((NumericNode) propertyNode).numberValue();
+        return propertyNode.numberValue();
       case POJO:
         return ((POJONode) propertyNode).getPojo();
       case STRING:
@@ -63,9 +61,29 @@ public class JsonNodeValueReader implements ValueReader<JsonNode> {
     }
   }
 
+  public Member<JsonNode> getMember(JsonNode source, String memberName) {
+    Object value = get(source, memberName);
+
+    if (value == null) {
+      return null;
+    } else if (value instanceof JsonNode) {
+      final JsonNode jsonNode = (JsonNode) value;
+      if (jsonNode.isMissingNode()) {
+        return null;
+      } else if (jsonNode.isContainerNode()) {
+        return new Member<JsonNode>(this, JsonNode.class, jsonNode);
+      } else {
+        // Should not be here
+        throw new IllegalArgumentException();
+      }
+    } else {
+      return new Member<JsonNode>(this, value.getClass());
+    }
+  }
+
   public Collection<String> memberNames(JsonNode source) {
     if (source.isObject())
-      return Lists.from(((ObjectNode) source).fieldNames());
+      return Lists.from(source.fieldNames());
     return null;
   }
 

--- a/extensions/jooq/src/main/java/org/modelmapper/jooq/RecordValueReader.java
+++ b/extensions/jooq/src/main/java/org/modelmapper/jooq/RecordValueReader.java
@@ -30,15 +30,27 @@ import org.modelmapper.spi.ValueReader;
  */
 public class RecordValueReader implements ValueReader<Record> {
   public Object get(Record source, String memberName) {
-    try {
-      for (Field<?> field : source.fields())
-        if (memberName.equalsIgnoreCase(field.getName()))
-          return source.getValue(field);
-      return null;
-    } catch (Exception e) {
-      throw new IllegalArgumentException(memberName
-          + " is not a valid member for the source record", e);
+    Field<?> field = matchField(source, memberName);
+    if (field != null) {
+      return source.getValue(field);
     }
+    return null;
+  }
+
+  public Member<Record> getMember(Record source, String memberName) {
+    Field<?> field = matchField(source, memberName);
+    if (field != null) {
+      return new Member<Record>(this, field.getType());
+    }
+
+    return null;
+  }
+
+  private Field<?> matchField(Record source, String memberName) {
+    for (Field<?> field : source.fields())
+      if (memberName.equalsIgnoreCase(field.getName()))
+        return field;
+    return null;
   }
 
   public Collection<String> memberNames(Record source) {

--- a/extensions/jooq/src/test/java/org/modelmapper/jooq/RecordValueReaderTest.java
+++ b/extensions/jooq/src/test/java/org/modelmapper/jooq/RecordValueReaderTest.java
@@ -1,16 +1,20 @@
 package org.modelmapper.jooq;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import java.sql.DriverManager;
 
 import org.jooq.DSLContext;
 import org.jooq.Record;
+import org.jooq.Result;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.PropertyMap;
 import org.modelmapper.convention.NameTokenizers;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -25,7 +29,6 @@ public class RecordValueReaderTest {
     Class.forName("org.h2.Driver");
     ctx = DSL.using(DriverManager.getConnection("jdbc:h2:mem:test"), SQLDialect.H2);
     ctx.execute("CREATE TABLE orders (id int(11), customer_id int(11), customer_street_address varchar(25), customer_address_city varchar(25), customer_address_zip varchar(10))");
-    ctx.execute("INSERT INTO orders values (456, 789, '123 Main Street', 'SF', null)");
   }
 
   public static class Order {
@@ -65,7 +68,14 @@ public class RecordValueReaderTest {
         .addValueReader(new RecordValueReader());
   }
 
+  @AfterMethod
+  public void afterMethod() {
+    ctx.execute("DELETE orders");
+  }
+
   public void shouldMapFromRecord() throws Exception {
+    ctx.execute("INSERT INTO orders values (456, 789, '123 Main Street', 'SF', null)");
+
     Record record = ctx.fetch("select * from orders").get(0);
 
     Order order = modelMapper.map(record, Order.class);
@@ -75,9 +85,14 @@ public class RecordValueReaderTest {
     assertEquals(order.customer.address.street, "123 Main Street");
     assertEquals(order.customer.address.city, "SF");
     assertEquals(order.customer.address.zip, null);
+
+    assertNotNull(modelMapper.getTypeMap(record.getClass(), Order.class));
+    modelMapper.validate();
   }
 
   public void shouldMapWithExplicitMapping() throws Exception {
+    ctx.execute("INSERT INTO orders values (456, 789, '123 Main Street', 'SF', null)");
+
     Record record = ctx.fetch("select * from orders").get(0);
 
     modelMapper.createTypeMap(record, Order.class).addMappings(new PropertyMap<Record, Order>() {
@@ -94,5 +109,32 @@ public class RecordValueReaderTest {
     assertEquals(order.customer.address.street, "123 Main Street");
     assertEquals(order.customer.address.city, "SF");
     assertEquals(order.customer.address.zip, null);
+
+    assertNotNull(modelMapper.getTypeMap(record.getClass(), Order.class));
+    modelMapper.validate();
+  }
+
+  public void shouldMapNullWell() throws Exception {
+    ctx.execute("INSERT INTO orders values (1, null, null, null, null)");
+    ctx.execute("INSERT INTO orders values (2, 789, '123 Main Street', 'SF', null)");
+
+    Result<Record> records = ctx.fetch("select * from orders order by id");
+
+    Order order = modelMapper.map(records.get(0), Order.class);
+
+    assertEquals(order.id, 1);
+    assertNull(order.customer);
+    assertNotNull(modelMapper.getTypeMap(records.get(0).getClass(), Order.class));
+
+    order = modelMapper.map(records.get(1), Order.class);
+
+    assertEquals(order.id, 2);
+    assertEquals(order.customer.id, 789);
+    assertEquals(order.customer.address.street, "123 Main Street");
+    assertEquals(order.customer.address.city, "SF");
+    assertEquals(order.customer.address.zip, null);
+    assertNotNull(modelMapper.getTypeMap(records.get(1).getClass(), Order.class));
+
+    modelMapper.validate();
   }
 }


### PR DESCRIPTION
Resolved:
#118 #133 #137 #168 #186 #188 #194

### Change 1 : new method ValueReader#getAccessor
#### Motivation
ValueReader should have two functionality.
One is at TypeMap building time (by ImplicitMappingBuilder), that it need to get accessors to build mappings in the TypeMap.
Another one is after TypeMap built, ModelMapper need to get the destination value.

So I think it would be better to separate into two methods.

#### Modification
- Introduce new class ValueAccessor, so that we won't expose internal class/method
- Implement JSON/JOOQ/MAP ValueReader#getAccessor

### Change 2: TypeMapStore#getOrCreate will cache TypeMap depends on situation
#### Motivation
Currently, we had problem on mapping dynamic type is that we always cache the TypeMap into TypeMapStore, even it was incomplete.
So I think we solution to solve the root cause, is that we don't save the wrong TypeMap into TypeMapStore, till the mappings ins TypeMap is completed.

#### Modification
- Check is completed or not when ModelMapper create a TypeMap and want saved it into TypeMapStore [1]
- Re-implement TypeMap#getUnmappedProperties [2]

[1] It only affect when ModelMapper create TypeMap automatically.
It means when we call ModelMapper#createTypeMap,  the TypeMap will always save into TypeMapStore that won't have this check.
Only when we call ModelMapper#map, and ModelMapper hadn't found a match TypeMap and it tries to create one by ImplicitMappingBuilder.
It will check that the source type is match to some of ValueReader and the mappings is completed or not.
All condition match, it will save it into TypeMapStore.

[2] In previous version, the getUnmappedProperties only check the 1st level fields.
But it will have problems when we have deep level fields.
In this PR, the unmapped properties will check deep-depth fields too.
It had some rules, if we had aaa.bbb.ccc as mapped properties,
then aaa, aaa.bbb, aaa.bbb.ccc, aaa.bbb.ccc.* are all marked as mapped properties.