### PR TITLE
Resolved #204: getting wrong type in PropertyInfoRegistry cache

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/ExplicitMappingVisitor.java
+++ b/core/src/main/java/org/modelmapper/internal/ExplicitMappingVisitor.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.modelmapper.internal.PropertyInfoImpl.FieldPropertyInfo;
@@ -45,7 +46,8 @@ public class ExplicitMappingVisitor extends ClassVisitor {
   private static final String MAP_SOURCE_METHOD_DESC = "(Ljava/lang/Object;)Ljava/lang/Object;";
   private static final String SKIP_DEST_METHOD_DESC = "(Ljava/lang/Object;)V";
   private static final String MAP_BOTH_METHOD_DESC = "(Ljava/lang/Object;Ljava/lang/Object;)V";
-  private static final String MUTATOR_METHOD_DESC_PATTERN = "(.+)V";
+
+  private static final Pattern MUTATOR_METHOD_DESC_PATTERN = Pattern.compile("^\\(.+\\)(.+)$");
 
   private final Errors errors;
   private final InheritingConfiguration config;
@@ -236,7 +238,13 @@ public class ExplicitMappingVisitor extends ClassVisitor {
     }
 
     private boolean isMutator(MethodInsnNode mn) {
-      return Pattern.matches(MUTATOR_METHOD_DESC_PATTERN, mn.desc);
+      Matcher matcher = MUTATOR_METHOD_DESC_PATTERN.matcher(mn.desc);
+      if (!matcher.find())
+        return false;
+
+      String returnType = matcher.group(1);
+      return returnType.equals("V")
+          || returnType.contains(mn.owner);
     }
 
     private void recordProperties() {

--- a/core/src/test/java/org/modelmapper/bugs/GH204.java
+++ b/core/src/test/java/org/modelmapper/bugs/GH204.java
@@ -1,0 +1,116 @@
+package org.modelmapper.bugs;
+
+import static org.testng.Assert.assertEquals;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.PropertyMap;
+import org.testng.annotations.Test;
+
+@Test
+public class GH204 extends AbstractTest {
+  static class SomeDto {
+    private String someValue;
+
+    public SomeDto() {
+    }
+
+    public SomeDto(String someValue) {
+      this.someValue = someValue;
+    }
+
+    public String someValue() {
+      return someValue;
+    }
+
+    public SomeDto someValue(String someValue) {
+      this.someValue = someValue;
+      return this;
+    }
+  }
+
+  static class SomeEntity {
+    private String otherValue;
+
+    public SomeEntity() {
+    }
+
+    public SomeEntity(String otherValue) {
+      this.otherValue = otherValue;
+    }
+
+    public String otherValue() {
+      return otherValue;
+    }
+
+    public SomeEntity otherValue(String otherValue) {
+      this.otherValue = otherValue;
+      return this;
+    }
+  }
+
+  public void shouldMappingMethod1() {
+    modelMapper.addMappings(new PropertyMap<SomeDto, SomeEntity>() {
+      @Override
+      protected void configure() {
+        map(source.someValue(), destination.otherValue(null));
+      }
+    });
+    modelMapper.addMappings(new PropertyMap<SomeEntity, SomeDto>() {
+      @Override
+      protected void configure() {
+        map(source.otherValue(), destination.someValue(null));
+      }
+    });
+
+    modelMapper.validate();
+
+    assertEquals("foo",
+        modelMapper.map(new SomeDto("foo"), SomeEntity.class).otherValue);
+    assertEquals("bar",
+        modelMapper.map(new SomeEntity("bar"), SomeDto.class).someValue);
+  }
+
+  public void shouldMappingMethod2() {
+    modelMapper.addMappings(new PropertyMap<SomeDto, SomeEntity>() {
+      @Override
+      protected void configure() {
+        map().otherValue(source.someValue());
+      }
+    });
+    modelMapper.addMappings(new PropertyMap<SomeEntity, SomeDto>() {
+      @Override
+      protected void configure() {
+        map().someValue(source.otherValue());
+      }
+    });
+
+    modelMapper.validate();
+
+    assertEquals("foo",
+        modelMapper.map(new SomeDto("foo"), SomeEntity.class).otherValue);
+    assertEquals("bar",
+        modelMapper.map(new SomeEntity("bar"), SomeDto.class).someValue);
+  }
+
+  public void shouldMappingMethod3() {
+    modelMapper.addMappings(new PropertyMap<SomeDto, SomeEntity>() {
+      @Override
+      protected void configure() {
+        map(source.someValue()).otherValue(null);
+      }
+    });
+    modelMapper.addMappings(new PropertyMap<SomeEntity, SomeDto>() {
+      @Override
+      protected void configure() {
+        map(source.otherValue()).someValue(null);
+      }
+    });
+
+    modelMapper.validate();
+
+    assertEquals("foo",
+        modelMapper.map(new SomeDto("foo"), SomeEntity.class).otherValue);
+    assertEquals("bar",
+        modelMapper.map(new SomeEntity("bar"), SomeDto.class).someValue);
+  }
+}


### PR DESCRIPTION
Currently, we found that when getter/setter had same
method name, then they will have same hash code when
we cache them. Then we had the risk for getting a
mutator when we try getting an accessor.

So I separate mutator, accessor, and field into three
different cache