### PR TITLE
Lambda friendly API

### DIFF
--- a/core/src/main/java/org/modelmapper/ExpressionMap.java
+++ b/core/src/main/java/org/modelmapper/ExpressionMap.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper;
+
+import org.modelmapper.builder.ConfigurableMapExpression;
+
+/**
+ * Represents an operation that accepts {@code mapping} and use functions
+ * defined in {@link ConfigurableMapExpression} to configure a {@link TypeMap}
+ *
+ * <pre>
+ *   modelMapper.addMappings(mapper -> {
+ *     mapper.map(Src::getA, Dest::setB);
+ *     mapper.using(converter).map(Src::getC, Dest::setD);
+ *   })
+ * </pre>
+ *
+ * @param <S> source type
+ * @param <D> destination type
+ *
+ * @author Chun Han Hsiao
+ */
+public interface ExpressionMap<S, D> {
+  /**
+   * Performs the operation to configure {@link TypeMap}
+   */
+  void configure(ConfigurableMapExpression<S, D> mapping);
+}

--- a/core/src/main/java/org/modelmapper/TypeMap.java
+++ b/core/src/main/java/org/modelmapper/TypeMap.java
@@ -17,8 +17,10 @@ package org.modelmapper;
 
 import java.util.List;
 
+import org.modelmapper.spi.DestinationSetter;
 import org.modelmapper.spi.Mapping;
 import org.modelmapper.spi.PropertyInfo;
+import org.modelmapper.spi.SourceGetter;
 
 /**
  * Encapsulates mapping configuration for a source and destination type pair.
@@ -227,4 +229,51 @@ public interface TypeMap<S, D> {
    * @throws ValidationException if any TypeMaps contain unmapped properties
    */
   void validate();
+
+  /**
+   * Adds a mapping into {@code TypeMap} by defining {@code sourceGetter} -> {@code destinationSetter}
+   *
+   * <pre>
+   * {@code
+   *   typeMap.addMapping(Src::getA, Dest::setB);
+   *   typeMap.<String>addMapping(src -> src.getC().getD(), (dest, value) -> dest.getE().setF(value))
+   * }
+   * </pre>
+   *
+   * @param sourceGetter source property getter
+   * @param destinationSetter destination property setter
+   * @param <V> type of destination property wants to be set
+   */
+  <V> TypeMap<S, D> addMapping(SourceGetter<S> sourceGetter, DestinationSetter<D, V> destinationSetter);
+
+  /**
+   * Add a mapping into {@code TypeMap} by defining a {@code mapper} action
+   *
+   * You can chain {@code addMappings} contains only one property mapping like
+   * <pre>
+   * {@code
+   *   typeMap.addMappings(mapper -> mapper.<String>map(Src::getA, Dest::setB))
+   *          .addMappings(mapper -> mapper.<String>skip(Dest::setB))
+   *          .addMappings(mapper -> mapper.when(condition).<String>map(Src::getA, Dest::setB))
+   *          .addMappings(mapper -> mapper.when(condition).<String>skip(Dest::setB))
+   *          .addMappings(mapper -> mapper.using(converter).<String>map(Src::getA, Dest::setB))
+   *          .addMappings(mapper -> mapper.with(provider).<String>map(Src::getA, Dest::setB));
+   * }
+   * </pre>
+   *
+   * Or you can define all property mappings in one {@code addMappings} like
+   * <pre>
+   * {@code
+   *   typeMap.addMappings(mapper -> {
+   *     mapper.<String>map(Src::getA, Dest::setB);
+   *     mapper.<String>skip(Dest::setB);
+   *     mapper.when(condition).<String>map(Src::getA, Dest::setB);
+   *   });
+   * }
+   * </pre>
+   *
+   * @param mapper a mapper defined a mapping action
+   * @return this typeMap
+   */
+  TypeMap<S, D> addMappings(ExpressionMap<S, D> mapper);
 }

--- a/core/src/main/java/org/modelmapper/builder/ConfigurableMapExpression.java
+++ b/core/src/main/java/org/modelmapper/builder/ConfigurableMapExpression.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.builder;
+
+import org.modelmapper.Condition;
+import org.modelmapper.Converter;
+import org.modelmapper.Provider;
+
+/**
+ * Represents mapping operations.
+ *
+ * @param <S> source type
+ * @param <D> destination type
+ *
+ * @author Chun Han Hsiao
+ */
+public interface ConfigurableMapExpression<S, D> extends ReferenceMapExpression<S, D> {
+  /**
+   * Uses {@code converter} to convert a source property to destination property
+   *
+   * <pre>
+   * {@code
+   *   using(converter).<String>map(Src::getCustomer, Dest::setCustomerId)
+   *   using(ctx -> ctx.getSource().getName().toUpperCase()).<String>map(src -> src.getCustomer().getId(), Dest::setCustomerId)
+   * }
+   * </pre>
+   *
+   * @param converter a converter convert source property to destination property
+   */
+  ReferenceMapExpression<S, D> using(Converter<?, ?> converter);
+
+  /**
+   * Uses {@code provider} to instantiate  an instance for destination property
+   *
+   * <pre>
+   * {@code
+   *   with(provider).<String>map(Src::getCustomer, Dest::setCustomer)
+   *   with(req -> new Customer()).<Customer>map(Src::getCustomer, Dest::setCustomer)
+   * }
+   * </pre>
+   *
+   * @param provider a provider instantiate destination property
+   */
+  ReferenceMapExpression<S, D> with(Provider<?> provider);
+
+  /**
+   * Uses {@code condition} to determine the mapping should fire or skip
+   *
+   * <pre>
+   * {@code
+   *   when(condition).<String>map(Src::getCustomer, Dest::setCustomer)
+   *   with(ctx -> ctx.getSource() != null).<Customer>map(Src::getCustomer, Dest::setCustomer)
+   * }
+   * </pre>
+   *
+   * @param condition a condition to apply the mapping action should be invoked or not
+   */
+  ReferenceMapExpression<S, D> when(Condition<?, ?> condition);
+}

--- a/core/src/main/java/org/modelmapper/builder/ReferenceMapExpression.java
+++ b/core/src/main/java/org/modelmapper/builder/ReferenceMapExpression.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.builder;
+
+import org.modelmapper.spi.DestinationSetter;
+import org.modelmapper.spi.SourceGetter;
+
+/**
+ * Represents mapping actions, to set a destination property from a source property,
+ * or to skip a destination property.
+ *
+ * @param <S> source type
+ * @param <D> destination type
+ *
+ * @author Chun Han Hsiao
+ */
+public interface ReferenceMapExpression<S, D> {
+  /**
+   * Map source getter value to destination setter
+   *
+   * <pre>
+   * {@code
+   *   <String>map(Src::getValue, Dest::setValue)
+   *   <String>map(src -> srg.getCustomer().getAddress(), dest -> dest.getCustomer().setAddress())
+   * }
+   * </pre>
+   *
+   * @param sourceGetter a method reference to source getter
+   * @param destinationSetter a method reference to destination setter
+   * @param <V> the value type to set into destination
+   */
+  <V> void map(SourceGetter<S> sourceGetter, DestinationSetter<D, V> destinationSetter);
+
+  /**
+   * Skip destination property based on {@code destinationSetter}
+   *
+   * <pre>
+   * {@code
+   *   <String>skip(Dest::setValue)
+   *   <String>map(dest -> dest.getCustomer().setAddress())
+   * }
+   * </pre>
+   *
+   * @param destinationSetter a method reference to destination setter
+   * @param <V> the value type of the setter
+   */
+  <V> void skip(DestinationSetter<D, V> destinationSetter);
+}

--- a/core/src/main/java/org/modelmapper/internal/ConfigurableMapExpressionImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/ConfigurableMapExpressionImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.internal;
+
+import static org.modelmapper.internal.ExplicitMappingBuilder.MappingOptions;
+import static org.modelmapper.internal.util.Assert.notNull;
+
+import org.modelmapper.Condition;
+import org.modelmapper.Converter;
+import org.modelmapper.Provider;
+import org.modelmapper.spi.DestinationSetter;
+import org.modelmapper.builder.ReferenceMapExpression;
+import org.modelmapper.spi.SourceGetter;
+import org.modelmapper.builder.ConfigurableMapExpression;
+
+/**
+ * {@link ConfigurableMapExpression} implementation
+ *
+ * @author Chun Han Hsiao
+ */
+class ConfigurableMapExpressionImpl<S, D> implements ConfigurableMapExpression<S, D> {
+  TypeMapImpl<S, D> typeMap;
+
+  public ConfigurableMapExpressionImpl(TypeMapImpl<S, D> typeMap) {
+    this.typeMap = typeMap;
+  }
+
+  public ReferenceMapExpression<S, D> using(Converter<?, ?> converter) {
+    notNull(converter, "converter");
+
+    MappingOptions options = new MappingOptions();
+    options.converter = converter;
+    return new ReferenceMapExpressionImpl<S, D>(typeMap, options);
+  }
+
+  public ReferenceMapExpression<S, D> with(Provider<?> provider) {
+    notNull(provider, "provider");
+
+    MappingOptions options = new MappingOptions();
+    options.provider = provider;
+    return new ReferenceMapExpressionImpl<S, D>(typeMap, options);
+  }
+
+  public ReferenceMapExpression<S, D> when(Condition<?, ?> condition) {
+    notNull(condition, "condition");
+
+    MappingOptions options = new MappingOptions();
+    options.condition = condition;
+    return new ReferenceMapExpressionImpl<S, D>(typeMap, options);
+  }
+
+  public <V> void map(SourceGetter<S> sourceGetter, DestinationSetter<D, V> destinationSetter) {
+    notNull(sourceGetter, "sourceGetter");
+    notNull(destinationSetter, "destinationSetter");
+    new ReferenceMapExpressionImpl<S, D>(typeMap).map(sourceGetter, destinationSetter);
+  }
+
+  public <V> void skip(DestinationSetter<D, V> destinationSetter) {
+    notNull(destinationSetter, "destinationSetter");
+    new ReferenceMapExpressionImpl<S, D>(typeMap).skip(destinationSetter);
+  }
+}

--- a/core/src/main/java/org/modelmapper/internal/PropertyReferenceCollector.java
+++ b/core/src/main/java/org/modelmapper/internal/PropertyReferenceCollector.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.internal;
+
+import static org.modelmapper.internal.ExplicitMappingBuilder.MappingOptions;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.modelmapper.spi.NameableType;
+
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.MethodProxy;
+
+/**
+ * Produces method interceptors that collect getters/setters invoke of the
+ * proxy object, and generate {@link MappingImpl}
+ *
+ * @author Chun Han Hsiao
+ */
+class PropertyReferenceCollector {
+  private InheritingConfiguration config;
+  private MappingOptions options;
+  private List<Accessor> accessors;
+  private List<Mutator> mutators;
+  private Errors errors;
+
+  PropertyReferenceCollector(InheritingConfiguration config, MappingOptions options) {
+    this.config = config;
+    this.options = options;
+    this.accessors = new ArrayList<Accessor>();
+    this.mutators = new ArrayList<Mutator>();
+    this.errors = new Errors();
+  }
+
+  public MethodInterceptor newSourceInterceptor() {
+    return new MethodInterceptor() {
+      public Object intercept(Object o, Method method, Object[] objects, MethodProxy methodProxy) throws Throwable {
+        visitSource(o.getClass(), method);
+
+        if (Void.class.isAssignableFrom(method.getReturnType()))
+          return null;
+        return ProxyFactory.proxyFor(method.getReturnType(), this, errors);
+      }
+    };
+  }
+
+  public MethodInterceptor newDestinationInterceptor() {
+    return new MethodInterceptor() {
+      public Object intercept(Object o, Method method, Object[] objects, MethodProxy methodProxy) throws Throwable {
+        visitDestination(o.getClass(), method);
+
+        if (Void.class.isAssignableFrom(method.getReturnType()))
+          return null;
+        return ProxyFactory.proxyFor(method.getReturnType(), this, new Errors());
+      }
+    };
+  }
+
+  private void visitSource(Class<?> type, Method method) {
+    if (PropertyInfoResolver.ACCESSORS.isValid(method)) {
+      String propertyName = config.getSourceNameTransformer().transform(method.getName(),
+          NameableType.METHOD);
+      accessors.add(PropertyInfoRegistry.accessorFor(type, method, config,
+          propertyName));
+    } else
+      errors.addMessage("Illegal SourceGetter method: %s.%s", type.getName(), method.getName());
+  }
+
+  private void visitDestination(Class<?> type, Method method) {
+    if (PropertyInfoResolver.MUTATORS.isValid(method)) {
+      String propertyName = config.getDestinationNameTransformer().transform(method.getName(),
+          NameableType.METHOD);
+      mutators.add(PropertyInfoRegistry.mutatorFor(type, method, config,
+          propertyName));
+    } else if (PropertyInfoResolver.ACCESSORS.isValid(method)) {
+      Mutator mutator = TypeInfoRegistry.typeInfoFor(type, config).mutatorForAccessorMethod(
+          method.getName());
+      if (mutator != null)
+        mutators.add(mutator);
+      else
+        errors.addMessage("No setter found: %s.%s", type.getName(), method.getName());
+    } else
+      errors.addMessage("Illegal DestinationSetter method: %s.%s", type.getName(), method.getName());
+  }
+
+  public MappingImpl collect() {
+    if ((!isSkip()) && accessors.isEmpty())
+      errors.addMessage("Illegal SourceGetter defined");
+    if (mutators.isEmpty())
+      errors.addMessage("Illegal DestinationSetter defined");
+
+    errors.throwConfigurationExceptionIfErrorsExist();
+    return new PropertyMappingImpl(accessors, mutators, options);
+  }
+
+  private boolean isSkip() {
+    return options.skipType > 0;
+  }
+
+  public Errors getErrors() {
+    return errors;
+  }
+}

--- a/core/src/main/java/org/modelmapper/internal/ReferenceMapExpressionImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/ReferenceMapExpressionImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.internal;
+
+import static org.modelmapper.internal.ExplicitMappingBuilder.MappingOptions;
+
+import org.modelmapper.internal.util.Primitives;
+import org.modelmapper.internal.util.TypeResolver;
+import org.modelmapper.spi.DestinationSetter;
+import org.modelmapper.builder.ReferenceMapExpression;
+import org.modelmapper.spi.SourceGetter;
+
+/**
+ * {@link ReferenceMapExpression} implementation
+ *
+ * @param <S> source type
+ * @param <D> destination type
+ *
+ * @author Chun Han Hsiao
+ */
+class ReferenceMapExpressionImpl<S, D> implements ReferenceMapExpression<S, D> {
+  private TypeMapImpl<S, D> typeMap;
+  private MappingOptions options;
+
+  public ReferenceMapExpressionImpl(TypeMapImpl<S, D> typeMap) {
+    this(typeMap, new MappingOptions());
+  }
+
+  public ReferenceMapExpressionImpl(TypeMapImpl<S, D> typeMap, MappingOptions options) {
+    this.typeMap = typeMap;
+    this.options = options;
+  }
+
+  public <V> void map(SourceGetter<S> sourceGetter, DestinationSetter<D, V> destinationSetter) {
+    PropertyReferenceCollector collector = new PropertyReferenceCollector(typeMap.configuration, options);
+
+    S source = ProxyFactory.proxyFor(typeMap.getSourceType(), collector.newSourceInterceptor(), collector.getErrors());
+    sourceGetter.get(source);
+
+    D destination = ProxyFactory.proxyFor(typeMap.getDestinationType(), collector.newDestinationInterceptor(), collector.getErrors());
+    destinationSetter.accept(destination, destinationValue(destinationSetter));
+
+    typeMap.addMapping(collector.collect());
+  }
+
+  public <V> void skip(DestinationSetter<D, V> destinationSetter) {
+    options.skipType = 1;
+
+    PropertyReferenceCollector collector = new PropertyReferenceCollector(typeMap.configuration, options);
+    D destination = ProxyFactory.proxyFor(typeMap.getDestinationType(), collector.newDestinationInterceptor(), collector.getErrors());
+    destinationSetter.accept(destination, destinationValue(destinationSetter));
+
+    typeMap.addMapping(collector.collect());
+  }
+
+  private <V> V destinationValue(DestinationSetter<D, V> destinationSetter) {
+    Class<?>[] typeArguments = TypeResolver.resolveArguments(destinationSetter.getClass(), DestinationSetter.class);
+    if (typeArguments != null) {
+      Class<?> valueClass = typeArguments[1];
+      if (Primitives.isPrimitive(valueClass)) {
+        return Primitives.defaultValue(Primitives.primitiveFor(valueClass));
+      }
+    }
+    return null;
+  }
+}

--- a/core/src/main/java/org/modelmapper/internal/TypeMapImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/TypeMapImpl.java
@@ -28,8 +28,11 @@ import org.modelmapper.Provider;
 import org.modelmapper.TypeMap;
 import org.modelmapper.internal.util.Assert;
 import org.modelmapper.internal.util.Types;
+import org.modelmapper.spi.DestinationSetter;
 import org.modelmapper.spi.Mapping;
 import org.modelmapper.spi.PropertyInfo;
+import org.modelmapper.spi.SourceGetter;
+import org.modelmapper.ExpressionMap;
 
 /**
  * TypeMap implementation.
@@ -209,6 +212,16 @@ class TypeMapImpl<S, D> implements TypeMap<S, D> {
 
   public TypeMap<S, D> setProvider(Provider<D> provider) {
     this.provider = Assert.notNull(provider, "provider");
+    return this;
+  }
+
+  public <V> TypeMap<S, D> addMapping(SourceGetter<S> sourceGetter, DestinationSetter<D, V> destinationSetter) {
+    new ReferenceMapExpressionImpl<S, D>(this).map(sourceGetter, destinationSetter);
+    return this;
+  }
+
+  public TypeMap<S, D> addMappings(ExpressionMap<S, D> mapper) {
+    mapper.configure(new ConfigurableMapExpressionImpl<S, D>(this));
     return this;
   }
 

--- a/core/src/main/java/org/modelmapper/spi/DestinationSetter.java
+++ b/core/src/main/java/org/modelmapper/spi/DestinationSetter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.spi;
+
+/**
+ * Represents an operation for setting a value into destination
+ *
+ * @param <D> destination type
+ * @param <V> argument type of the setter
+ *
+ * @author Chun Han Hsiao
+ */
+public interface DestinationSetter<D, V> {
+  /**
+   * Performs this operation to set the value into destination
+   *
+   * @param destination the instance of destination
+   * @param value the value from source
+   */
+  void accept(D destination, V value);
+}

--- a/core/src/main/java/org/modelmapper/spi/SourceGetter.java
+++ b/core/src/main/java/org/modelmapper/spi/SourceGetter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.spi;
+
+/**
+ * Represents an operation for getting an property from source
+ *
+ * @param <S> source type
+ *
+ * @author Chun Han Hsiao
+ */
+public interface SourceGetter<S> {
+  /**
+   * Performs this operation to get a value from source
+   *
+   * @param source the source instance
+   * @return the property from source
+   */
+  Object get(S source);
+}

--- a/core/src/test/java/org/modelmapper/functional/lambda/TypeMapLambdaDeepMapTest.java
+++ b/core/src/test/java/org/modelmapper/functional/lambda/TypeMapLambdaDeepMapTest.java
@@ -1,0 +1,154 @@
+package org.modelmapper.functional.lambda;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.Asserts;
+import org.modelmapper.Condition;
+import org.modelmapper.ConfigurationException;
+import org.modelmapper.Converter;
+import org.modelmapper.ExpressionMap;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.Provider;
+import org.modelmapper.TypeMap;
+import org.modelmapper.builder.ConfigurableMapExpression;
+import org.modelmapper.spi.DestinationSetter;
+import org.modelmapper.spi.MappingContext;
+import org.modelmapper.spi.SourceGetter;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test
+public class TypeMapLambdaDeepMapTest extends AbstractTest {
+  static class ParentSrc {
+    Src src;
+
+    public ParentSrc(Src src) {
+      this.src = src;
+    }
+
+    public Src getSrc() {
+      return src;
+    }
+
+    public void setSrc(Src src) {
+      this.src = src;
+    }
+  }
+
+  static class Src {
+    String srcText;
+
+    public Src(String srcText) {
+      this.srcText = srcText;
+    }
+
+    public String getSrcText() {
+      return srcText;
+    }
+
+    public void setSrcText(String srcText) {
+      this.srcText = srcText;
+    }
+  }
+
+  static class ParentDest {
+    Dest dest;
+
+    public Dest getDest() {
+      return dest;
+    }
+
+    public void setDest(Dest dest) {
+      this.dest = dest;
+    }
+  }
+
+  static class Dest {
+    String destText;
+
+    public String getDestText() {
+      return destText;
+    }
+
+    public void setDestText(String destText) {
+      this.destText = destText;
+    }
+  }
+
+  @BeforeMethod
+  public void setUp() {
+    modelMapper = new ModelMapper();
+    modelMapper.getConfiguration().setImplicitMappingEnabled(false);
+  }
+
+  public void shouldAddMappingDeeply() {
+    TypeMap<ParentSrc, ParentDest> typeMap = modelMapper.createTypeMap(ParentSrc.class, ParentDest.class);
+    typeMap.addMapping(parentSrcGetter(), parentDestSetter());
+
+    typeMap.validate();
+    assertEquals(typeMap.map(new ParentSrc(new Src("bar"))).getDest().destText, "bar");
+  }
+
+  public void shouldAddMappingWithProvider() {
+    final Dest dest = new Dest();
+
+    TypeMap<ParentSrc, ParentDest> typeMap = modelMapper.createTypeMap(ParentSrc.class, ParentDest.class);
+    typeMap.addMappings(
+        new ExpressionMap<ParentSrc, ParentDest>() {
+          public void configure(ConfigurableMapExpression<ParentSrc, ParentDest> mapping) {
+            mapping.with(new Provider<Dest>() {
+              public Dest get(ProvisionRequest<Dest> request) {
+                return dest;
+              }
+            }).map(new SourceGetter<ParentSrc>() {
+              public Object get(ParentSrc source) {
+                return source.getSrc();
+              }
+            }, new DestinationSetter<ParentDest, Dest>() {
+              public void accept(ParentDest destination, Dest value) {
+                destination.setDest(value);
+              }
+            });
+          }
+        });
+
+    typeMap.validate();
+    assertSame(typeMap.map(new ParentSrc(new Src("foo"))).dest, dest);
+  }
+
+  private static SourceGetter<ParentSrc> parentSrcGetter() {
+    return new SourceGetter<ParentSrc>() {
+      public Object get(ParentSrc source) {
+        return source.getSrc().getSrcText();
+      }
+    };
+  }
+
+  private static SourceGetter<Src> srcGetter() {
+    return new SourceGetter<Src>() {
+      public Object get(Src source) {
+        return source.getSrcText();
+      }
+    };
+  }
+
+  private static DestinationSetter<ParentDest, String> parentDestSetter() {
+    return new DestinationSetter<ParentDest, String>() {
+      public void accept(ParentDest destination, String value) {
+        destination.getDest().setDestText(value);
+      }
+    };
+  }
+
+  private static DestinationSetter<Dest, String> destSetter() {
+    return new DestinationSetter<Dest, String>() {
+      public void accept(Dest destination, String value) {
+        destination.setDestText(value);
+      }
+    };
+  }
+}

--- a/core/src/test/java/org/modelmapper/functional/lambda/TypeMapLambdaMultipleFieldsTest.java
+++ b/core/src/test/java/org/modelmapper/functional/lambda/TypeMapLambdaMultipleFieldsTest.java
@@ -1,0 +1,206 @@
+package org.modelmapper.functional.lambda;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.Condition;
+import org.modelmapper.Converter;
+import org.modelmapper.ExpressionMap;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.modelmapper.builder.ConfigurableMapExpression;
+import org.modelmapper.spi.DestinationSetter;
+import org.modelmapper.spi.MappingContext;
+import org.modelmapper.spi.SourceGetter;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test
+public class TypeMapLambdaMultipleFieldsTest extends AbstractTest {
+  static class Src {
+    private String srcText;
+    private int srcNumber;
+
+    public Src(String srcText, int srcNumber) {
+      this.srcText = srcText;
+      this.srcNumber = srcNumber;
+    }
+
+    public String getSrcText() {
+      return srcText;
+    }
+
+    public void setSrcText(String srcText) {
+      this.srcText = srcText;
+    }
+
+    public int getSrcNumber() {
+      return srcNumber;
+    }
+
+    public void setSrcNumber(int srcNumber) {
+      this.srcNumber = srcNumber;
+    }
+  }
+
+  static class Dest {
+    private String destText;
+    private int destNumber;
+
+    public String getDestText() {
+      return destText;
+    }
+
+    public void setDestText(String destText) {
+      this.destText = destText;
+    }
+
+    public int getDestNumber() {
+      return destNumber;
+    }
+
+    public void setDestNumber(int destNumber) {
+      this.destNumber = destNumber;
+    }
+  }
+
+  @BeforeMethod
+  public void setUp() {
+    modelMapper = new ModelMapper();
+    modelMapper.getConfiguration().setImplicitMappingEnabled(false);
+  }
+
+  public void shouldAddMapping() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+    typeMap.addMapping(srcTextGetter(), destTextSetter());
+    typeMap.addMapping(srcNumberGetter(), destNumberSetter());
+
+    typeMap.validate();
+
+    Dest dest = typeMap.map(new Src("foo", 3));
+    assertEquals(dest.destText, "foo");
+    assertEquals(dest.destNumber, 3);
+  }
+
+  public void shouldAddMappings() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+    typeMap.addMappings(new ExpressionMap<Src, Dest>() {
+      public void configure(ConfigurableMapExpression<Src, Dest> mapping) {
+        mapping.map(srcTextGetter(), destTextSetter());
+        mapping.map(srcNumberGetter(), destNumberSetter());
+      }
+    });
+
+    typeMap.validate();
+
+    Dest dest = typeMap.map(new Src("foo", 3));
+    assertEquals(dest.destText, "foo");
+    assertEquals(dest.destNumber, 3);
+  }
+
+  public void shouldAddMappingWithConverter() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+    typeMap.addMappings(
+        new ExpressionMap<Src, Dest>() {
+          public void configure(ConfigurableMapExpression<Src, Dest> mapping) {
+            mapping.using(new Converter<String, String>() {
+              public String convert(MappingContext<String, String> context) {
+                return context.getSource().toUpperCase();
+              }
+            }).map(srcTextGetter(), destTextSetter());
+            mapping.using(new Converter<Integer, Integer>() {
+              public Integer convert(MappingContext<Integer, Integer> context) {
+                return context.getSource() + 1;
+              }
+            }).map(srcNumberGetter(), destNumberSetter());
+          }
+        });
+
+    typeMap.validate();
+
+    Dest dest = typeMap.map(new Src("foo", 3));
+    assertEquals(dest.destText, "FOO");
+    assertEquals(dest.destNumber, 4);
+  }
+
+  public void shouldAddMappingWithSkip() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+    typeMap.addMappings(
+        new ExpressionMap<Src, Dest>() {
+          public void configure(ConfigurableMapExpression<Src, Dest> mapping) {
+            mapping.skip(destTextSetter());
+            mapping.map(srcNumberGetter(), destNumberSetter());
+          }
+        });
+
+    typeMap.validate();
+
+    Dest dest = typeMap.map(new Src("foo", 3));
+    assertNull(dest.destText);
+    assertEquals(dest.destNumber, 3);
+  }
+
+  public void shouldAddMappingWithCondition() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+    typeMap.addMappings(
+        new ExpressionMap<Src, Dest>() {
+          public void configure(ConfigurableMapExpression<Src, Dest> mapping) {
+            mapping.when(new Condition<String, String>() {
+              public boolean applies(MappingContext<String, String> context) {
+                return context.getSource().equals("foo");
+              }
+            }).map(srcTextGetter(), destTextSetter());
+            mapping.when(new Condition<Integer, Integer>() {
+              public boolean applies(MappingContext<Integer, Integer> context) {
+                return context.getSource() > 3;
+              }
+            }).map(srcNumberGetter(), destNumberSetter());
+          }
+        });
+
+    typeMap.validate();
+
+    Dest dest1 = typeMap.map(new Src("bar", 3));
+    assertNull(dest1.destText);
+    assertEquals(dest1.destNumber, 0);
+
+    Dest dest2 = typeMap.map(new Src("foo", 4));
+    assertEquals(dest2.destText, "foo");
+    assertEquals(dest2.destNumber, 4);
+  }
+
+
+  private static SourceGetter<Src> srcTextGetter() {
+    return new SourceGetter<Src>() {
+      public Object get(Src source) {
+        return source.getSrcText();
+      }
+    };
+  }
+
+
+  private static SourceGetter<Src> srcNumberGetter() {
+    return new SourceGetter<Src>() {
+      public Object get(Src source) {
+        return source.getSrcNumber();
+      }
+    };
+  }
+
+  private static DestinationSetter<Dest, String> destTextSetter() {
+    return new DestinationSetter<Dest, String>() {
+      public void accept(Dest destination, String value) {
+        destination.setDestText(value);
+      }
+    };
+  }
+
+  private static DestinationSetter<Dest, Integer> destNumberSetter() {
+    return new DestinationSetter<Dest, Integer>() {
+      public void accept(Dest destination, Integer value) {
+        destination.setDestNumber(value);
+      }
+    };
+  }
+}

--- a/core/src/test/java/org/modelmapper/functional/lambda/TypeMapLambdaTest.java
+++ b/core/src/test/java/org/modelmapper/functional/lambda/TypeMapLambdaTest.java
@@ -1,0 +1,176 @@
+package org.modelmapper.functional.lambda;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.Asserts;
+import org.modelmapper.Condition;
+import org.modelmapper.ConfigurationException;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.Provider;
+import org.modelmapper.TypeMap;
+import org.modelmapper.spi.DestinationSetter;
+import org.modelmapper.spi.MappingContext;
+import org.modelmapper.spi.SourceGetter;
+import org.modelmapper.ExpressionMap;
+import org.modelmapper.builder.ConfigurableMapExpression;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test
+public class TypeMapLambdaTest extends AbstractTest {
+  static class Src {
+    String srcText;
+
+    public Src(String srcText) {
+      this.srcText = srcText;
+    }
+
+    public String getSrcText() {
+      return srcText;
+    }
+
+    public void setSrcText(String srcText) {
+      this.srcText = srcText;
+    }
+  }
+
+  static class Dest {
+    String destText;
+
+    public String getDestText() {
+      return destText;
+    }
+
+    public void setDestText(String destText) {
+      this.destText = destText;
+    }
+  }
+
+  @BeforeMethod
+  public void setUp() {
+    modelMapper = new ModelMapper();
+    modelMapper.getConfiguration().setImplicitMappingEnabled(false);
+  }
+
+  public void shouldAddMapping() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+    typeMap.addMapping(srcGetter(), destSetter());
+
+    typeMap.validate();
+    assertEquals(typeMap.map(new Src("foo")).destText, "foo");
+  }
+
+  public void shouldAddMappingWithConverter() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+    typeMap.addMappings(
+        new ExpressionMap<Src, Dest>() {
+          public void configure(ConfigurableMapExpression<Src, Dest> mapping) {
+            mapping.using(new Converter<String, String>() {
+              public String convert(MappingContext<String, String> context) {
+                return context.getSource().toUpperCase();
+              }
+            }).map(srcGetter(), destSetter());
+          }
+        });
+
+    typeMap.validate();
+    assertEquals(typeMap.map(new Src("foo")).destText, "FOO");
+  }
+
+  public void shouldAddMappingWithSkip() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+    typeMap.addMappings(
+        new ExpressionMap<Src, Dest>() {
+          public void configure(ConfigurableMapExpression<Src, Dest> mapping) {
+            mapping.skip(destSetter());
+          }
+        });
+
+    typeMap.validate();
+    assertNull(typeMap.map(new Src("foo")).destText);
+  }
+
+  public void shouldAddMappingWithCondition() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+    typeMap.addMappings(
+        new ExpressionMap<Src, Dest>() {
+          public void configure(ConfigurableMapExpression<Src, Dest> mapping) {
+            mapping.when(new Condition<String, String>() {
+              public boolean applies(MappingContext<String, String> context) {
+                return context.getSource().equals("foo");
+              }
+            }).map(srcGetter(), destSetter());
+          }
+        });
+
+    typeMap.validate();
+    assertNull(typeMap.map(new Src("bar")).destText);
+    assertEquals(typeMap.map(new Src("foo")).destText, "foo");
+  }
+
+  public void shouldFailedWithEmptySourceGetter() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+
+    try {
+      typeMap.addMapping(new SourceGetter<Src>() {
+        public Object get(Src source) {
+          return source;
+        }
+      }, destSetter());
+      fail();
+    } catch (ConfigurationException e) {
+      Asserts.assertContains(e.getMessage(), "Illegal SourceGetter defined");
+    }
+  }
+
+  public void shouldFailedWithEmptyDestinationSetter() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+
+    try {
+      typeMap.addMapping(srcGetter(), new DestinationSetter<Dest, String>() {
+        public void accept(Dest destination, String value) {
+        }
+      });
+      fail();
+    } catch (ConfigurationException e) {
+      Asserts.assertContains(e.getMessage(), "Illegal DestinationSetter defined");
+    }
+  }
+
+  public void shouldFailedWithWrongSourceGetter() {
+    TypeMap<Src, Dest> typeMap = modelMapper.createTypeMap(Src.class, Dest.class);
+
+    try {
+      typeMap.addMapping(new SourceGetter<Src>() {
+        public Object get(Src source) {
+          return source.toString();
+        }
+      }, destSetter());
+      fail();
+    } catch (ConfigurationException e) {
+      Asserts.assertContains(e.getMessage(), "Illegal SourceGetter defined");
+    }
+  }
+
+
+  private static SourceGetter<Src> srcGetter() {
+    return new SourceGetter<Src>() {
+      public Object get(Src source) {
+        return source.getSrcText();
+      }
+    };
+  }
+
+  private static DestinationSetter<Dest, String> destSetter() {
+    return new DestinationSetter<Dest, String>() {
+      public void accept(Dest destination, String value) {
+        destination.setDestText(value);
+      }
+    };
+  }
+}

--- a/core/src/test/java/org/modelmapper/functional/lambda/TypeMapLambdaTypeConvertTest.java
+++ b/core/src/test/java/org/modelmapper/functional/lambda/TypeMapLambdaTypeConvertTest.java
@@ -1,0 +1,81 @@
+package org.modelmapper.functional.lambda;
+
+import static org.testng.Assert.assertEquals;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.modelmapper.TypeToken;
+import org.modelmapper.spi.DestinationSetter;
+import org.modelmapper.spi.SourceGetter;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test
+public class TypeMapLambdaTypeConvertTest extends AbstractTest {
+  static class StringWrap {
+    private String value;
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+  }
+
+  static class IntegerWrap {
+    private int value;
+
+    public int getValue() {
+      return value;
+    }
+
+    public void setValue(int value) {
+      this.value = value;
+    }
+  }
+
+  @BeforeMethod
+  public void setUp() {
+    modelMapper = new ModelMapper();
+    modelMapper.getConfiguration().setImplicitMappingEnabled(false);
+  }
+
+  public void shouldAddMappingStringToInteger() {
+    TypeMap<StringWrap, IntegerWrap> typeMap = modelMapper.createTypeMap(StringWrap.class, IntegerWrap.class);
+
+    typeMap.addMapping(new SourceGetter<StringWrap>() {
+      public Object get(StringWrap source) {
+        return source.getValue();
+      }
+    }, new DestinationSetter<IntegerWrap, Integer>() {
+      public void accept(IntegerWrap destination, Integer value) {
+        destination.setValue(value);
+      }
+    });
+
+    StringWrap src = new StringWrap();
+    src.setValue("3");
+    assertEquals(modelMapper.map(src, IntegerWrap.class).value, 3);
+  }
+
+  public void shouldAddMappingIntegerToString() {
+    TypeMap<IntegerWrap, StringWrap> typeMap = modelMapper.createTypeMap(IntegerWrap.class, StringWrap.class);
+
+    typeMap.addMapping(new SourceGetter<IntegerWrap>() {
+      public Object get(IntegerWrap source) {
+        return source.getValue();
+      }
+    }, new DestinationSetter<StringWrap, String>() {
+      public void accept(StringWrap destination, String value) {
+        destination.setValue(value);
+      }
+    });
+
+    IntegerWrap src = new IntegerWrap();
+    src.setValue(3);
+    assertEquals(modelMapper.map(src, StringWrap.class).value, "3");
+  }
+}


### PR DESCRIPTION
Provide lambda friendly api
The demo please reference [Unit Test](https://github.com/chhsiao90/modelmapper/blob/lambda-demo/misc/misc-lambda/src/test/java/org/modelmapper/misc/lambda/TypeMapTest.java)

#### TypeMap.addMapping(SourceGetter, DestinationSetter)
```java
typeMap.addMapping(Src::getA, Dest::setB);
typeMap.addMapping(src -> src.getA().getB(), dest, v -> dest.getC().setD(v));
```

#### ~~TypeMap.addMapping(TypeMapMapper)~~ TypeMap.addMappings(TypeMapMapper)
You can do like this
```java
typeMap.addMappings(mapping -> mapping.with(provider).map(Src::getA, Dest::setB));
typeMap.addMappings(mapping -> mapping.using(converter).map(Src::getA, Dest::setB));
typeMap.addMappings(mapping -> mapping.when(condition).map(Src::getA, Dest::setB));
typeMap.addMappings(mapping -> mapping.skip(Dest::setB));
```

or like this
```java
typeMap.addMappings(mapping -> {
  mapping.with(provider).map(Src::getA, Dest::setB);
  mapping.using(converter).map(Src::getA, Dest::setB);
  mapping.when(condition).map(Src::getA, Dest::setB);
  mapping -> mapping.skip(Dest::setB);
});
```

#### ~~ModelMapper.addMappings(TypeMapMapper)~~
Please use typeMap.createTypeMap(Src.class, Dest.class).addMappings(...) instead