### PR TITLE
Introduce ModelMapper.typeMap()

### DIFF
--- a/core/src/main/java/org/modelmapper/ModelMapper.java
+++ b/core/src/main/java/org/modelmapper/ModelMapper.java
@@ -314,6 +314,37 @@ public class ModelMapper {
   }
 
   /**
+   * Returns the TypeMap for the {@code sourceType}, {@code destinationType}, creates TypeMap
+   * automatically if none exists.
+   *
+   * @param <S> source type
+   * @param <D> destination type
+   * @throws IllegalArgumentException is {@code sourceType}, {@code destinationType} are null
+   */
+  public <S, D> TypeMap<S, D> typeMap(Class<S> sourceType, Class<D> destinationType) {
+    Assert.notNull(sourceType, "sourceType");
+    Assert.notNull(destinationType, "destinationType");
+    return config.typeMapStore.getOrCreate(null, sourceType, destinationType, null, engine);
+  }
+
+  /**
+   * Returns the TypeMap for the {@code sourceType}, {@code destinationType}, and {@code typeMapName}
+   * creates TypeMap automatically if none exists.
+   *
+   * @param <S> source type
+   * @param <D> destination type
+   * @throws IllegalArgumentException is {@code sourceType}, {@code destinationType} or
+   *           {@code typeMapName} are null
+   */
+  public <S, D> TypeMap<S, D> typeMap(Class<S> sourceType, Class<D> destinationType,
+      String typeMapName) {
+    Assert.notNull(sourceType, "sourceType");
+    Assert.notNull(destinationType, "destinationType");
+    Assert.notNull(typeMapName, "typeMapName");
+    return config.typeMapStore.getOrCreate(null, sourceType, destinationType, typeMapName, engine);
+  }
+
+  /**
    * Returns all TypeMaps for the ModelMapper.
    */
   public Collection<TypeMap<?, ?>> getTypeMaps() {

--- a/core/src/test/java/org/modelmapper/ModelMapperTest.java
+++ b/core/src/test/java/org/modelmapper/ModelMapperTest.java
@@ -1,9 +1,6 @@
 package org.modelmapper;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 
 import java.util.Map;
 
@@ -132,5 +129,22 @@ public class ModelMapperTest extends AbstractTest {
       Asserts.assertContains(e.getMessage(),
           "Must declare source type argument <S> and destination type argument <D> for converter");
     }
+  }
+
+  public void shouldTypeMapCreateOrGet() {
+    TypeMap<Person, PersonDTO> typeMap = modelMapper.typeMap(Person.class, PersonDTO.class);
+    assertNotNull(typeMap);
+    assertSame(modelMapper.typeMap(Person.class, PersonDTO.class), typeMap);
+
+    TypeMap<Person, PersonDTO> typeMapWithName = modelMapper.typeMap(Person.class, PersonDTO.class, "foo");
+    assertNotNull(typeMapWithName);
+    assertNotSame(typeMapWithName, typeMap);
+    assertSame(modelMapper.typeMap(Person.class, PersonDTO.class, "foo"), typeMapWithName);
+
+    TypeMap<Person, PersonDTO> typeMapWithDifferentName = modelMapper.typeMap(Person.class, PersonDTO.class, "bar");
+    assertNotNull(typeMapWithDifferentName);
+    assertNotSame(typeMapWithDifferentName, typeMap);
+    assertNotSame(typeMapWithDifferentName, typeMapWithName);
+    assertSame(modelMapper.typeMap(Person.class, PersonDTO.class, "bar"), typeMapWithDifferentName);
   }
 }


### PR DESCRIPTION
Provides a shortcut for create or get a TypeMap in a ModelMapper

Closed: #214