### PR TITLE
Remove unneeded generic types

### DIFF
--- a/core/src/main/java/org/modelmapper/TypeMap.java
+++ b/core/src/main/java/org/modelmapper/TypeMap.java
@@ -15,12 +15,12 @@
  */
 package org.modelmapper;
 
-import java.util.List;
-
 import org.modelmapper.spi.DestinationSetter;
 import org.modelmapper.spi.Mapping;
 import org.modelmapper.spi.PropertyInfo;
 import org.modelmapper.spi.SourceGetter;
+
+import java.util.List;
 
 /**
  * Encapsulates mapping configuration for a source and destination type pair.
@@ -242,9 +242,8 @@ public interface TypeMap<S, D> {
    *
    * @param sourceGetter source property getter
    * @param destinationSetter destination property setter
-   * @param <V> type of destination property wants to be set
    */
-  <V> TypeMap<S, D> addMapping(SourceGetter<S> sourceGetter, DestinationSetter<D, V> destinationSetter);
+  TypeMap<S, D> addMapping(SourceGetter<S> sourceGetter, DestinationSetter<D, ?> destinationSetter);
 
   /**
    * Add a mapping into {@code TypeMap} by defining a {@code mapper} action

--- a/core/src/main/java/org/modelmapper/builder/ReferenceMapExpression.java
+++ b/core/src/main/java/org/modelmapper/builder/ReferenceMapExpression.java
@@ -40,9 +40,8 @@ public interface ReferenceMapExpression<S, D> {
    *
    * @param sourceGetter a method reference to source getter
    * @param destinationSetter a method reference to destination setter
-   * @param <V> the value type to set into destination
    */
-  <V> void map(SourceGetter<S> sourceGetter, DestinationSetter<D, V> destinationSetter);
+  void map(SourceGetter<S> sourceGetter, DestinationSetter<D, ?> destinationSetter);
 
   /**
    * Skip destination property based on {@code destinationSetter}
@@ -55,7 +54,6 @@ public interface ReferenceMapExpression<S, D> {
    * </pre>
    *
    * @param destinationSetter a method reference to destination setter
-   * @param <V> the value type of the setter
    */
-  <V> void skip(DestinationSetter<D, V> destinationSetter);
+  void skip(DestinationSetter<D, ?> destinationSetter);
 }

--- a/core/src/main/java/org/modelmapper/internal/ConfigurableMapExpressionImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/ConfigurableMapExpressionImpl.java
@@ -62,13 +62,13 @@ class ConfigurableMapExpressionImpl<S, D> implements ConfigurableMapExpression<S
     return new ReferenceMapExpressionImpl<S, D>(typeMap, options);
   }
 
-  public <V> void map(SourceGetter<S> sourceGetter, DestinationSetter<D, V> destinationSetter) {
+  public void map(SourceGetter<S> sourceGetter, DestinationSetter<D, ?> destinationSetter) {
     notNull(sourceGetter, "sourceGetter");
     notNull(destinationSetter, "destinationSetter");
     new ReferenceMapExpressionImpl<S, D>(typeMap).map(sourceGetter, destinationSetter);
   }
 
-  public <V> void skip(DestinationSetter<D, V> destinationSetter) {
+  public void skip(DestinationSetter<D, ?> destinationSetter) {
     notNull(destinationSetter, "destinationSetter");
     new ReferenceMapExpressionImpl<S, D>(typeMap).skip(destinationSetter);
   }

--- a/core/src/main/java/org/modelmapper/internal/TypeMapImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/TypeMapImpl.java
@@ -227,7 +227,7 @@ class TypeMapImpl<S, D> implements TypeMap<S, D> {
     return this;
   }
 
-  public <V> TypeMap<S, D> addMapping(SourceGetter<S> sourceGetter, DestinationSetter<D, V> destinationSetter) {
+  public TypeMap<S, D> addMapping(SourceGetter<S> sourceGetter, DestinationSetter<D, ?> destinationSetter) {
     new ReferenceMapExpressionImpl<S, D>(this).map(sourceGetter, destinationSetter);
     return this;
   }


### PR DESCRIPTION
We don't need to explicit define the setter's value type when defining
expression mapping, so we removed it!