### PR TITLE
Fix field matching bug

### DIFF
--- a/core/src/main/java/org/modelmapper/convention/InexactMatcher.java
+++ b/core/src/main/java/org/modelmapper/convention/InexactMatcher.java
@@ -56,7 +56,7 @@ class InexactMatcher {
             return (dstIndex - dstStartIndex) + 1;
           // Done with dest tokens
           if (dstIndex == dst.length - 1)
-            return 0;
+            break;
 
           dstStr = dst[++dstIndex];
           dstCharIndex = 0;
@@ -66,7 +66,8 @@ class InexactMatcher {
         if (srcCharIndex == srcStr.length() - 1) {
           // Done with source tokens
           if (srcIndex == src.length - 1)
-            return 0;
+            break;
+
           srcStr = src[++srcIndex];
           srcCharIndex = 0;
         } else

--- a/core/src/test/java/org/modelmapper/bugs/GH234.java
+++ b/core/src/test/java/org/modelmapper/bugs/GH234.java
@@ -1,0 +1,48 @@
+package org.modelmapper.bugs;
+
+import static org.testng.Assert.assertEquals;
+
+import org.modelmapper.ModelMapper;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test
+public class GH234 {
+  static class A {
+    private String testGooGo;
+
+    public String getTestGooGo() {
+      return testGooGo;
+    }
+
+    public void setTestGooGo(String testGooGo) {
+      this.testGooGo = testGooGo;
+    }
+  }
+
+  static class B {
+    private String testGooGo;
+
+    public String getTestGooGo() {
+      return testGooGo;
+    }
+
+    public void setTestGooGo(String testGooGo) {
+      this.testGooGo = testGooGo;
+    }
+  }
+
+  private ModelMapper modelMapper;
+
+  @BeforeMethod
+  public void setUp() {
+    modelMapper = new ModelMapper();
+  }
+
+  public void shouldMap() {
+    A a = new A();
+    a.setTestGooGo("foo");
+
+    assertEquals(modelMapper.map(a, B.class).getTestGooGo(), "foo");
+  }
+}

--- a/core/src/test/java/org/modelmapper/convention/InexactMatcherTest.java
+++ b/core/src/test/java/org/modelmapper/convention/InexactMatcherTest.java
@@ -40,7 +40,7 @@ public class InexactMatcherTest {
     assertEquals(
         matchTokens(new String[] { "customer", "fiRst", "naMe" },
             new String[] { "cusTomFirstname" }, 0), 0);
-    assertEquals(matchTokens(new String[] { "oo", "a", "aaa" }, new String[] { "aa", "a" }, 0), 0);
+    assertEquals(matchTokens(new String[] { "oo", "a", "aaa" }, new String[] { "aa", "a" }, 0), 2);
     assertEquals(matchTokens(new String[] { "aabbc", "cc" }, new String[] { "aa", "bb", "cc" }, 0),
         0);
     assertEquals(
@@ -54,5 +54,11 @@ public class InexactMatcherTest {
         matchTokens(new String[] { "my", "firstNaMe" }, new String[] { "my", "asdf", "first" }, 2),
         0);
     assertEquals(matchTokens(new String[] { "a", "a", "a" }, new String[] { "b" }, 0), 0);
+
+    assertEquals(matchTokens(new String[] { "goo", "go" }, new String[] { "goo", "go" }, 0), 1);
+    assertEquals(matchTokens(new String[] { "goo", "go" }, new String[] { "goo", "go" }, 1), 1);
+
+    assertEquals(matchTokens(new String[] { "go", "goo" }, new String[] { "go", "goo" }, 0), 1);
+    assertEquals(matchTokens(new String[] { "go", "goo" }, new String[] { "go", "goo" }, 1), 1);
   }
 }


### PR DESCRIPTION
When source property tokens contains similar destination property token,
the matcher seams will skip matching process even there is a full match
token exist. For instance, with given destination property token: go, it
will failed to find matched token with given source tokens: goo, go.

Closed: #234