### PR TITLE
Add a configuration option: skipNull

### DIFF
--- a/core/src/main/java/org/modelmapper/config/Configuration.java
+++ b/core/src/main/java/org/modelmapper/config/Configuration.java
@@ -207,6 +207,14 @@ public interface Configuration {
   boolean isImplicitMappingEnabled();
 
   /**
+   * Returns whether a property mapping will be skipped if the property value is {@code null}.
+   * When {@code true}, ModelMapper will always not set {@code null} to destination property.
+   *
+   * @see #setSkipNullEnabled(boolean)
+   */
+  boolean isSkipNullEnabled();
+
+  /**
    * Sets whether destination properties that match more than one source property should be ignored.
    * When true, ambiguous destination properties are skipped during the matching process. When
    * false, a ConfigurationException is thrown when ambiguous properties are encountered.
@@ -281,6 +289,14 @@ public interface Configuration {
    * @see #isImplicitMappingEnabled()
    */
   Configuration setImplicitMappingEnabled(boolean enabled);
+
+  /**
+   * Sets whether a property should be skipped or not when the property value is {@code null}.
+   *
+   * @param enabled whether skip null is enabled
+   * @see #isSkipNullEnabled()
+   */
+  Configuration setSkipNullEnabled(boolean enabled);
 
   /**
    * Sets the strategy used to match source properties to destination properties.

--- a/core/src/main/java/org/modelmapper/internal/InheritingConfiguration.java
+++ b/core/src/main/java/org/modelmapper/internal/InheritingConfiguration.java
@@ -59,6 +59,7 @@ public class InheritingConfiguration implements Configuration {
   private Boolean ambiguityIgnored;
   private Boolean fullTypeMatchingRequired;
   private Boolean implicitMatchingEnabled;
+  private Boolean skipNullEnabled;
 
   /**
    * Creates an initial InheritingConfiguration.
@@ -81,6 +82,7 @@ public class InheritingConfiguration implements Configuration {
     ambiguityIgnored = Boolean.FALSE;
     fullTypeMatchingRequired = Boolean.FALSE;
     implicitMatchingEnabled = Boolean.TRUE;
+    skipNullEnabled = Boolean.FALSE;
   }
 
   /**
@@ -111,6 +113,7 @@ public class InheritingConfiguration implements Configuration {
       propertyCondition = source.propertyCondition;
       fullTypeMatchingRequired = source.fullTypeMatchingRequired;
       implicitMatchingEnabled = source.implicitMatchingEnabled;
+      skipNullEnabled = source.skipNullEnabled;
     }
   }
 
@@ -238,6 +241,11 @@ public class InheritingConfiguration implements Configuration {
         : implicitMatchingEnabled;
   }
 
+  public boolean isSkipNullEnabled() {
+    return skipNullEnabled == null ? parent.isSkipNullEnabled()
+        : skipNullEnabled;
+  }
+
   public Configuration setAmbiguityIgnored(boolean ignore) {
     this.ambiguityIgnored = ignore;
     return this;
@@ -275,6 +283,11 @@ public class InheritingConfiguration implements Configuration {
 
   public Configuration setImplicitMappingEnabled(boolean enabled) {
     implicitMatchingEnabled = enabled;
+    return this;
+  }
+
+  public Configuration setSkipNullEnabled(boolean enabled) {
+    skipNullEnabled = enabled;
     return this;
   }
 

--- a/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
@@ -252,9 +252,10 @@ public class MappingEngineImpl implements MappingEngine {
           destinationValue = map(propertyContext);
 
         context.destinationCache.put(destPath, destinationValue);
-        mutator.setValue(destination,
-            destinationValue == null ? Primitives.defaultValue(mutator.getType())
-                : destinationValue);
+        if (destinationValue != null || !configuration.isSkipNullEnabled())
+          mutator.setValue(destination,
+              destinationValue == null ? Primitives.defaultValue(mutator.getType())
+                  : destinationValue);
         if (destinationValue == null)
           context.shadePath(propertyContext.destinationPath);
       } else {

--- a/core/src/test/java/org/modelmapper/functional/skip/EnableSkipNullTest.java
+++ b/core/src/test/java/org/modelmapper/functional/skip/EnableSkipNullTest.java
@@ -1,0 +1,113 @@
+package org.modelmapper.functional.skip;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.Condition;
+import org.modelmapper.Converter;
+import org.modelmapper.PropertyMap;
+import org.modelmapper.spi.MappingContext;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class EnableSkipNullTest extends AbstractTest {
+  static class UserDto {
+    private String userId;
+
+    public String getUserId() {
+      return userId;
+    }
+
+    public void setUserId(String userId) {
+      this.userId = userId;
+    }
+  }
+
+  static class ActiveUserEntity {
+    private String id;
+    private String uuid;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public String getUuid() {
+      return uuid;
+    }
+
+    public void setUuid(String uuid) {
+      this.uuid = uuid;
+    }
+  }
+
+  @BeforeMethod
+  public void setUp() {
+    modelMapper.getConfiguration().setSkipNullEnabled(true);
+  }
+
+  public void shouldSkipNull() {
+    ActiveUserEntity destination = new ActiveUserEntity();
+    destination.setId("foo");
+    destination.setUuid("bar");
+
+    modelMapper.map(new UserDto(), destination);
+
+    assertEquals(destination.getId(), "foo");
+    assertEquals(destination.getUuid(), "bar");
+  }
+
+  public void shouldSkipNullWithPropertyMapSkipFailed() {
+    final Condition<Object, Object> alwaysFalse = new Condition<Object, Object>() {
+      public boolean applies(MappingContext<Object, Object> context) {
+        return false;
+      }
+    };
+
+    modelMapper.addMappings(new PropertyMap<UserDto, ActiveUserEntity>() {
+      @Override
+      protected void configure() {
+        when(alwaysFalse).skip().setId(null);
+        when(alwaysFalse).skip().setUuid(null);
+      }
+    });
+
+    ActiveUserEntity destination = new ActiveUserEntity();
+    destination.setId("foo");
+    destination.setUuid("bar");
+
+    modelMapper.map(new UserDto(), destination);
+
+    assertEquals(destination.getId(), "foo");
+    assertEquals(destination.getUuid(), "bar");
+  }
+
+  public void shouldSkipNullWithConverter() {
+    final Converter<Object, Object> converter = new Converter<Object, Object>() {
+      public Object convert(MappingContext<Object, Object> context) {
+        return context.getSource();
+      }
+    };
+
+    modelMapper.addMappings(new PropertyMap<UserDto, ActiveUserEntity>() {
+      @Override
+      protected void configure() {
+        using(converter).map(source.getUserId()).setId(null);
+        using(converter).map(source.getUserId()).setUuid(null);
+      }
+    });
+
+    ActiveUserEntity destination = new ActiveUserEntity();
+    destination.setId("foo");
+    destination.setUuid("bar");
+
+    modelMapper.map(new UserDto(), destination);
+
+    assertEquals(destination.getId(), "foo");
+    assertEquals(destination.getUuid(), "bar");
+  }
+}


### PR DESCRIPTION
Sometimes we don't want to map a null value to be set into
destination property, so we provide an option to configure
whether we should skip mapping null value to destination
property or not.

Resolved: #217