### PR TITLE
Returns null instead of throw error for ProxyClass

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/PropertyReferenceCollector.java
+++ b/core/src/main/java/org/modelmapper/internal/PropertyReferenceCollector.java
@@ -38,6 +38,7 @@ class PropertyReferenceCollector {
   private List<Accessor> accessors;
   private List<Mutator> mutators;
   private Errors errors;
+  private Errors proxyErrors;
 
   PropertyReferenceCollector(InheritingConfiguration config, MappingOptions options) {
     this.config = config;
@@ -45,6 +46,7 @@ class PropertyReferenceCollector {
     this.accessors = new ArrayList<Accessor>();
     this.mutators = new ArrayList<Mutator>();
     this.errors = new Errors();
+    this.proxyErrors = new Errors();
   }
 
   public MethodInterceptor newSourceInterceptor() {
@@ -54,7 +56,12 @@ class PropertyReferenceCollector {
 
         if (Void.class.isAssignableFrom(method.getReturnType()))
           return null;
-        return ProxyFactory.proxyFor(method.getReturnType(), this, errors);
+
+        try {
+          return ProxyFactory.proxyFor(method.getReturnType(), this, proxyErrors);
+        } catch (ErrorsException e) {
+          return null;
+        }
       }
     };
   }
@@ -66,7 +73,7 @@ class PropertyReferenceCollector {
 
         if (Void.class.isAssignableFrom(method.getReturnType()))
           return null;
-        return ProxyFactory.proxyFor(method.getReturnType(), this, new Errors());
+        return ProxyFactory.proxyFor(method.getReturnType(), this, proxyErrors);
       }
     };
   }
@@ -114,5 +121,9 @@ class PropertyReferenceCollector {
 
   public Errors getErrors() {
     return errors;
+  }
+
+  public Errors getProxyErrors() {
+    return proxyErrors;
   }
 }

--- a/core/src/main/java/org/modelmapper/internal/ReferenceMapExpressionImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/ReferenceMapExpressionImpl.java
@@ -49,10 +49,24 @@ class ReferenceMapExpressionImpl<S, D> implements ReferenceMapExpression<S, D> {
     PropertyReferenceCollector collector = new PropertyReferenceCollector(typeMap.configuration, options);
 
     S source = ProxyFactory.proxyFor(typeMap.getSourceType(), collector.newSourceInterceptor(), collector.getErrors());
-    sourceGetter.get(source);
+
+    try {
+      sourceGetter.get(source);
+    } catch (NullPointerException e) {
+      if (collector.getProxyErrors().hasErrors())
+        throw collector.getProxyErrors().toException();
+      throw e;
+    }
 
     D destination = ProxyFactory.proxyFor(typeMap.getDestinationType(), collector.newDestinationInterceptor(), collector.getErrors());
-    destinationSetter.accept(destination, destinationValue(destinationSetter));
+
+    try {
+      destinationSetter.accept(destination, destinationValue(destinationSetter));
+    } catch (NullPointerException e) {
+      if (collector.getProxyErrors().hasErrors())
+        throw collector.getProxyErrors().toException();
+      throw e;
+    }
 
     typeMap.addMapping(collector.collect());
   }

--- a/core/src/test/java/org/modelmapper/functional/enums/EnumSetMappingTest.java
+++ b/core/src/test/java/org/modelmapper/functional/enums/EnumSetMappingTest.java
@@ -1,0 +1,124 @@
+package org.modelmapper.functional.enums;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import org.modelmapper.AbstractProvider;
+import org.modelmapper.Converter;
+import org.modelmapper.ExpressionMap;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.PropertyMap;
+import org.modelmapper.Provider;
+import org.modelmapper.builder.ConfigurableMapExpression;
+import org.modelmapper.spi.DestinationSetter;
+import org.modelmapper.spi.MappingContext;
+import org.modelmapper.spi.SourceGetter;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+@Test
+public class EnumSetMappingTest {
+	private enum E {
+    E1, E2, E3, E4
+	}
+
+	static class A {
+		private EnumSet<E> enumsA;
+
+		public EnumSet<E> getEnumsA() {
+			return enumsA;
+		}
+		public void setEnumsA(EnumSet<E> enumsA) {
+			this.enumsA = enumsA;
+		}
+	}
+
+
+	static class B {
+		private EnumSet<E> enumsB;
+
+		public EnumSet<E> getEnumsB() {
+			return enumsB;
+		}
+		public void setEnumsB(EnumSet<E> enumsB) {
+			this.enumsB = enumsB;
+		}
+	}
+
+	private static Converter<EnumSet<?>, EnumSet<?>> enumConverter = new Converter<EnumSet<?>, EnumSet<?>>() {
+		public EnumSet<?> convert(MappingContext<EnumSet<?>, EnumSet<?>> context) {
+			Object source = context.getSource();
+			if (source == null)
+				return null;
+
+			return EnumSet.copyOf((EnumSet<?>) source);
+		}
+
+	};
+
+	private ModelMapper initMapperWithPropertyMap() {
+		ModelMapper mapper = new ModelMapper();
+		mapper.addMappings(new PropertyMap<A, B>() {
+			@Override
+			protected void configure() {
+				using(enumConverter).map(source.getEnumsA()).setEnumsB(null);
+			}
+		});
+		return mapper;
+	}
+
+	private ModelMapper initMapperWithAddMapping() {
+		ModelMapper mapper = new ModelMapper();
+		mapper.typeMap(A.class, B.class)
+				.addMappings(new ExpressionMap<A, B>() {
+					public void configure(ConfigurableMapExpression<A, B> mapping) {
+						mapping.using(enumConverter).map(new SourceGetter<A>() {
+							public Object get(A source) {
+								return source.getEnumsA();
+							}
+						}, new DestinationSetter<B, EnumSet<E>>() {
+							public void accept(B destination, EnumSet<E> value) {
+								destination.setEnumsB(value);
+							}
+						});
+					}
+				});
+		return mapper;
+	}
+
+	private List<ModelMapper> mappers() {
+		return Arrays.asList(
+				initMapperWithPropertyMap(), initMapperWithAddMapping());
+	}
+
+	public void testEnumSetWithValues() {
+		for (ModelMapper mapper : mappers()) {
+			A a = new A();
+			a.enumsA = EnumSet.of(E.E1, E.E2);
+			B b = mapper.map(a, B.class);
+			mapper.validate();
+
+			assertTrue(b.getEnumsB().contains(E.E1));
+			assertTrue(b.getEnumsB().contains(E.E2));
+		}
+	}
+
+
+	public void testEnumSetAsEmpty() {
+		for (ModelMapper mapper : mappers()) {
+			A a = new A();
+			B b = mapper.map(a, B.class);
+			mapper.validate();
+
+			assertNull(b.getEnumsB());
+		}
+	}
+}


### PR DESCRIPTION
We try to proxy all properties when user build an explicit map,
but we cannot proxy some class with cglib like EnumSet. But for
some case, we don't need to proxy all properties, so we try to
return null instead of throw error instantly. And we throw errors
when we got NullPointerException.

Resolved: #260