### PR TITLE
OSGi class loader bridge

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -110,14 +110,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestFile>target/classes/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
@@ -180,13 +172,36 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack-shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <version>${project.version}</version>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}/classes</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <version>2.3.7</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>
-            <phase>process-classes</phase>
+            <phase>package</phase>
             <goals>
               <goal>manifest</goal>
             </goals>
@@ -196,6 +211,9 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
+              org.modelmapper.internal.cglib.proxy;version=${cglib.version},
+              org.modelmapper.internal.cglib.core;version=${cglib.version},
+              org.modelmapper.internal.cglib.transform;version=${cglib.version},
               org.modelmapper,
               org.modelmapper.builder,
               org.modelmapper.config,
@@ -204,45 +222,33 @@
             </Export-Package>
             <Private-Package>
               org.modelmapper.internal.**
-            </Private-Package>
-            <Import-Package>
-              !net.sf.cglib.*,*
-            </Import-Package>
-            <Include-Resource>
-              {maven-resources},
-              {maven-dependencies}
-            </Include-Resource>
+            </Private-Package>          
           </instructions>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-replacer-plugin</groupId>
-        <artifactId>replacer</artifactId>
-        <version>1.5.2</version>
+        <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
+            <id>package-pre-shaded</id>
             <phase>prepare-package</phase>
             <goals>
-              <goal>replace</goal>
+              <goal>jar</goal>
             </goals>
           </execution>
+          <execution>
+            <id>package-bundle</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifestFile>target/classes/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
         </executions>
-        <configuration>
-          <!-- the maven-bundle-plugin discards the shaded packages from Export-Package, so we have to 
-            add them like this. -->
-          <file>${project.build.outputDirectory}/META-INF/MANIFEST.MF</file>
-          <regex>false</regex>
-          <replacements>
-            <replacement>
-              <token>Export-Package: org.modelmapper</token>
-              <value>Export-Package: org.modelmapper.internal.cglib.proxy;version=${cglib.version},
-                org.modelmapper.internal.cglib.core;version=${cglib.version},
-                org.modelmapper.internal.cglib.transform;version=${cglib.version},
-                org.modelmapper
-              </value>
-            </replacement>
-          </replacements>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/core/src/main/java/org/modelmapper/config/Configuration.java
+++ b/core/src/main/java/org/modelmapper/config/Configuration.java
@@ -30,7 +30,7 @@ import org.modelmapper.spi.ValueReader;
 
 /**
  * Configures conventions used during the matching process.
- * 
+ *
  * @author Jonathan Halterman
  */
 public interface Configuration {
@@ -50,10 +50,10 @@ public interface Configuration {
 
   /**
    * Registers the {@code valueReader} to use when mapping from instances of types {@code T}.
-   * 
+   *
    * <p>
    * This method is part of the ModelMapper SPI.
-   * 
+   *
    * @param <T> source type
    * @param valueReader to register
    * @throws IllegalArgumentException if {@code valueReader} is null or if type argument {@code T}
@@ -70,7 +70,7 @@ public interface Configuration {
    * Gets the ordered list of internal conditional converters that are used to perform type
    * conversion. This list is mutable and may be modified to control which converters are used to
    * perform type conversion along with the order in which converters are selected.
-   * 
+   *
    * <p>
    * This method is part of the ModelMapper SPI.
    */
@@ -78,42 +78,42 @@ public interface Configuration {
 
   /**
    * Returns the destination name tokenizer.
-   * 
+   *
    * @see #setDestinationNameTokenizer(NameTokenizer)
    */
   NameTokenizer getDestinationNameTokenizer();
 
   /**
    * Returns the destination name transformer.
-   * 
+   *
    * @see #setDestinationNameTransformer(NameTransformer)
    */
   NameTransformer getDestinationNameTransformer();
 
   /**
    * Returns the destination naming convention.
-   * 
+   *
    * @see #setDestinationNamingConvention(NamingConvention)
    */
   NamingConvention getDestinationNamingConvention();
 
   /**
    * Returns the field access level.
-   * 
+   *
    * @see #setFieldAccessLevel(AccessLevel)
    */
   AccessLevel getFieldAccessLevel();
 
   /**
    * Gets the matching strategy.
-   * 
+   *
    * @see #setMatchingStrategy(MatchingStrategy)
    */
   MatchingStrategy getMatchingStrategy();
 
   /**
    * Returns the method access level.
-   * 
+   *
    * @see #setMethodAccessLevel(AccessLevel)
    */
   AccessLevel getMethodAccessLevel();
@@ -121,7 +121,7 @@ public interface Configuration {
   /**
    * Returns the Condition that must apply for a property in order for mapping to take place, else
    * {@code null} if no condition has been configured.
-   * 
+   *
    * @see #setPropertyCondition(Condition)
    */
   Condition<?, ?> getPropertyCondition();
@@ -129,28 +129,28 @@ public interface Configuration {
   /**
    * Returns the Provider used for provisioning destination object instances, else {@code null} if
    * no Provider has been configured.
-   * 
+   *
    * @see #setProvider(Provider)
    */
   Provider<?> getProvider();
 
   /**
    * Returns the source name tokenizer.
-   * 
+   *
    * @see #setSourceNameTokenizer(NameTokenizer)
    */
   NameTokenizer getSourceNameTokenizer();
 
   /**
    * Returns the source name transformer.
-   * 
+   *
    * @see #setSourceNameTransformer(NameTransformer)
    */
   NameTransformer getSourceNameTransformer();
 
   /**
    * Gets the source naming convention.
-   * 
+   *
    * @see #setSourceNamingConvention(NamingConvention)
    */
   NamingConvention getSourceNamingConvention();
@@ -160,11 +160,11 @@ public interface Configuration {
    * used to read source object values during mapping. This list is may be modified to control which
    * ValueReaders are used to along with the order in which ValueReaders are selected for a source
    * type.
-   * 
+   *
    * <p>
    * The returned List throws an IllegalArgumentException when attempting to add or set a
    * ValueReader for which the type argument {@code T} has not been defined.
-   * 
+   *
    * <p>
    * This method is part of the ModelMapper SPI.
    */
@@ -173,14 +173,14 @@ public interface Configuration {
   /**
    * Returns {@code true} if ambiguous properties are ignored or {@code false} if they will result
    * in an exception.
-   * 
+   *
    * @see #setAmbiguityIgnored(boolean)
    */
   boolean isAmbiguityIgnored();
 
   /**
    * Returns whether field matching is enabled.
-   * 
+   *
    * @see #setFieldMatchingEnabled(boolean)
    */
   boolean isFieldMatchingEnabled();
@@ -191,7 +191,7 @@ public interface Configuration {
    * {@link MatchResult#PARTIAL partial} match.
    * <p>
    * Default is {@code false}.
-   * 
+   *
    * @see #setFullTypeMatchingRequired(boolean)
    */
   boolean isFullTypeMatchingRequired();
@@ -201,7 +201,7 @@ public interface Configuration {
    * will implicitly map source to destination properties based on configured conventions. When
    * {@code false}, only explicit mappings defined in {@link PropertyMap property maps} will be
    * used.
-   * 
+   *
    * @see #setImplicitMappingEnabled(boolean)
    */
   boolean isImplicitMappingEnabled();
@@ -215,10 +215,17 @@ public interface Configuration {
   boolean isSkipNullEnabled();
 
   /**
+   * Returns whether OSGi Class Loader Bridging is required.
+   *
+   * @see #setUseOSGiClassLoaderBridging(boolean)
+   */
+  boolean isUseOSGiClassLoaderBridging();
+
+  /**
    * Sets whether destination properties that match more than one source property should be ignored.
    * When true, ambiguous destination properties are skipped during the matching process. When
    * false, a ConfigurationException is thrown when ambiguous properties are encountered.
-   * 
+   *
    * @param ignore whether ambiguity is to be ignored
    * @see #isAmbiguityIgnored()
    */
@@ -227,7 +234,7 @@ public interface Configuration {
   /**
    * Sets the tokenizer to be applied to destination property and class names during the matching
    * process.
-   * 
+   *
    * @throws IllegalArgumentException if {@code nameTokenizer} is null
    */
   Configuration setDestinationNameTokenizer(NameTokenizer nameTokenizer);
@@ -235,25 +242,25 @@ public interface Configuration {
   /**
    * Sets the name transformer used to transform destination property and class names during the
    * matching process.
-   * 
+   *
    * @throws IllegalArgumentException if {@code nameTransformer} is null
    */
   Configuration setDestinationNameTransformer(NameTransformer nameTransformer);
 
   /**
    * Sets the convention used to identify destination property names during the matching process.
-   * 
+   *
    * @throws IllegalArgumentException if {@code namingConvention} is null
    */
   Configuration setDestinationNamingConvention(NamingConvention namingConvention);
 
   /**
    * Indicates that fields should be eligible for matching at the given {@code accessLevel}.
-   * 
+   *
    * <p>
    * <b>Note</b>: Field access is only used when {@link #setFieldMatchingEnabled(boolean) field
    * matching} is enabled.
-   * 
+   *
    * @throws IllegalArgumentException if {@code accessLevel} is null
    * @see #setFieldMatchingEnabled(boolean)
    */
@@ -262,7 +269,7 @@ public interface Configuration {
   /**
    * Sets whether field matching should be enabled. When true, mapping may take place between
    * accessible fields. Default is {@code false}.
-   * 
+   *
    * @param enabled whether field matching is enabled
    * @see #isFieldMatchingEnabled()
    * @see #setFieldAccessLevel(AccessLevel)
@@ -273,7 +280,7 @@ public interface Configuration {
    * Set whether {@link ConditionalConverter}s must define a {@link MatchResult#FULL full} match in
    * order to be applied. If {@code false}, conditional converters may also be applied for a
    * {@link MatchResult#PARTIAL partial} match.
-   * 
+   *
    * @param required whether full type matching is required for conditional converters.
    * @see #isFullTypeMatchingRequired()
    */
@@ -284,7 +291,7 @@ public interface Configuration {
    * implicitly map source to destination properties based on configured conventions. When
    * {@code false}, only explicit mappings defined in {@link PropertyMap property maps} will be
    * used.
-   * 
+   *
    * @param enabled whether implicit matching is enabled
    * @see #isImplicitMappingEnabled()
    */
@@ -299,15 +306,36 @@ public interface Configuration {
   Configuration setSkipNullEnabled(boolean enabled);
 
   /**
+   * Sets whether to use an OSGi Class Loader Bridge as described in the following article:
+   * https://www.infoq.com/articles/code-generation-with-osgi
+   * <p>
+   * This eliminates the need for forcing ModelMapper users to add custom OSGi imports to cglib's internals.
+   * <p>
+   * In addition to that, the Class Loader Bridge will attempt to solve the issue described in the following StackOverflow topic:
+   * https://stackoverflow.com/questions/47854086/cglib-creating-class-proxy-in-osgi-results-in-noclassdeffounderror
+   * <p>
+   * Ideally, this is expected to eliminate class loading issues in OSGi environments that were caused by missing custom imports.
+   * <p>
+   * <b>Note</b>:
+   * If Class Loader Bridging is selected, then the source and destination class types must not be package-private.
+   * That is because in Java, two classes are only consider equal to the JRE if they were loaded with the same class loader even if they otherwise represent an identical class.
+   * The same is true for Java packages. If a class is loaded with a different class loader, it cannot get private-package access to any classes (or class members) that belong to another class loader.
+   *
+   * @param useOSGiClassLoaderBridging whether to use OSGi Class Loader Bridge. Default is false
+   * @see #isUseOSGiClassLoaderBridging()
+   */
+  Configuration setUseOSGiClassLoaderBridging(boolean useOSGiClassLoaderBridging);
+
+  /**
    * Sets the strategy used to match source properties to destination properties.
-   * 
+   *
    * @throws IllegalArgumentException if {@code matchingStrategy} is null
    */
   Configuration setMatchingStrategy(MatchingStrategy matchingStrategy);
 
   /**
    * Indicates that methods should be eligible for matching at the given {@code accessLevel}.
-   * 
+   *
    * @throws IllegalArgumentException if {@code accessLevel} is null
    * @see AccessLevel
    */
@@ -316,14 +344,14 @@ public interface Configuration {
   /**
    * Sets the {@code condition} that must apply for a property in order for mapping to take place.
    * This is overridden by any property conditions defined in a TypeMap or PropertyMap.
-   * 
+   *
    * @throws IllegalArgumentException if {@code condition} is null
    */
   Configuration setPropertyCondition(Condition<?, ?> condition);
 
   /**
    * Sets the {@code provider} to use for providing destination object instances.
-   * 
+   *
    * @param provider to register
    * @throws IllegalArgumentException if {@code provider} is null
    */
@@ -332,7 +360,7 @@ public interface Configuration {
   /**
    * Sets the tokenizer to be applied to source property and class names during the matching
    * process.
-   * 
+   *
    * @throws IllegalArgumentException if {@code nameTokenizer} is null
    */
   Configuration setSourceNameTokenizer(NameTokenizer nameTokenizer);
@@ -340,14 +368,14 @@ public interface Configuration {
   /**
    * Sets the name transformer used to transform source property and class names during the matching
    * process.
-   * 
+   *
    * @throws IllegalArgumentException if {@code nameTransformer} is null
    */
   Configuration setSourceNameTransformer(NameTransformer nameTransformer);
 
   /**
    * Sets the convention used to identify source property names during the matching process.
-   * 
+   *
    * @throws IllegalArgumentException if {@code namingConvention} is null
    */
   Configuration setSourceNamingConvention(NamingConvention namingConvention);

--- a/core/src/main/java/org/modelmapper/internal/BridgeClassLoaderFactory.java
+++ b/core/src/main/java/org/modelmapper/internal/BridgeClassLoaderFactory.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.internal;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.modelmapper.ModelMapper;
+
+/**
+ * Using Bridge Class Loader approach as described in the following article:
+ * https://www.infoq.com/articles/code-generation-with-osgi
+ * <p>
+ * This eliminates the need for forcing ModelMapper users to add custom OSGi imports to cglib's internals.
+ * <p>
+ * In addition to that, this Class Loader attempts to solve the issue described in the following StackOverflow topic:
+ * https://stackoverflow.com/questions/47854086/cglib-creating-class-proxy-in-osgi-results-in-noclassdeffounderror
+ * <p>
+ * This can also easily be solved by introducing a Dynamic-ImportPackage: * in ModelMapper's MANIFEST.MF
+ * But this feels like an overkill.
+ * Instead, we take a bit different approach.
+ * Since with Bridging we already defined a separate class space for enchanted classes, we might as well try to
+ * include in the resolving procedure the ClassLoaders of class types that the User's type inherits from.
+ * That way, we make sure to delegate class loading of types that are otherwise unknown to the User's bundle
+ * (such as javax.xml.datatype.XMLGregorianCalendar in the StackOverflow topic) to the respective Bundle's ClassLoader
+ * that actually uses the type.
+ *
+ * @author m.dzhigarov
+ */
+public class BridgeClassLoaderFactory {
+  private static final class BridgeClassLoader extends ClassLoader {
+    private final ClassLoader internalClassSpace; // Bridging the internal lib class space as described in https://www.infoq.com/articles/code-generation-with-osgi
+    private final Set<ClassLoader> additionalClassLoaders; // Additional Class Loaders in attempt to solve https://stackoverflow.com/questions/47854086/cglib-creating-class-proxy-in-osgi-results-in-noclassdeffounderror
+
+    BridgeClassLoader(ClassLoader primary) {
+      super(primary);
+      internalClassSpace = ModelMapper.class.getClassLoader(); // ModelMapper's own ClassLoader must know how to load its internals
+      additionalClassLoaders = Collections.newSetFromMap(new ConcurrentHashMap<ClassLoader, Boolean>());
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+      if (name.startsWith("org.modelmapper.internal.cglib"))
+        return internalClassSpace.loadClass(name);
+
+      for (ClassLoader additionalClassLoader : additionalClassLoaders) {
+        try {
+          return additionalClassLoader.loadClass(name);
+        }
+        catch (ClassNotFoundException e) {
+          // Don't mind... Attempt next class loader
+        }
+      }
+
+      throw new ClassNotFoundException(name);
+    }
+
+    private void addAdditionalClassLoaders(Set<ClassLoader> additionalClassLoaders) {
+      additionalClassLoaders.remove(this.getParent()); // Make sure that the parent ClassLoader is not part of the collection. Otherwise, a recursion might occur in findClass().
+      this.additionalClassLoaders.addAll(additionalClassLoaders);
+    }
+  }
+
+  private static final Map<ClassLoader, WeakReference<BridgeClassLoader>> CACHE = new WeakHashMap<ClassLoader, WeakReference<BridgeClassLoader>>();
+  static ClassLoader getClassLoader(Class<?> appType) {
+    Set<Class<?>> allExtendedOrImplementedTypesRecursively = getAllExtendedOrImplementedTypesRecursively(appType);
+    Set<ClassLoader> allClassLoadersInTheTypeHierarchy = getAllClassLoadersInTheTypeHierarchy(allExtendedOrImplementedTypesRecursively);
+
+    synchronized (BridgeClassLoaderFactory.class) {
+      BridgeClassLoader bridgeClassLoader = null;
+      WeakReference<BridgeClassLoader> bridgeClassLoaderRef = CACHE.get(appType.getClassLoader());
+      if (bridgeClassLoaderRef != null) {
+        bridgeClassLoader = bridgeClassLoaderRef.get();
+      }
+
+      if (bridgeClassLoader == null) {
+        bridgeClassLoader = new BridgeClassLoader(appType.getClassLoader());
+        CACHE.put(appType.getClassLoader(), new WeakReference<BridgeClassLoader>(bridgeClassLoader));
+      }
+
+      bridgeClassLoader.addAdditionalClassLoaders(allClassLoadersInTheTypeHierarchy);
+
+      return bridgeClassLoader;
+    }
+  }
+
+  private static Set<ClassLoader> getAllClassLoadersInTheTypeHierarchy(Set<Class<?>> allExtendedOrImplementedTypesRecursively) {
+    Set<ClassLoader> result = new HashSet<ClassLoader>();
+    for (Class<?> clazz : allExtendedOrImplementedTypesRecursively) {
+      if (clazz.getClassLoader() != null) {
+        result.add(clazz.getClassLoader());
+      }
+    }
+
+    return result;
+  }
+
+  // Extracted from https://stackoverflow.com/questions/22031207/find-all-classes-and-interfaces-a-class-extends-or-implements-recursively
+  private static Set<Class<?>> getAllExtendedOrImplementedTypesRecursively(Class<?> clazzArg) {
+    Class<?> clazz = clazzArg;
+    List<Class<?>> res = new ArrayList<Class<?>>();
+
+    do {
+      res.add(clazz);
+
+      // First, add all the interfaces implemented by this class
+      Class<?>[] interfaces = clazz.getInterfaces();
+      if (interfaces.length > 0) {
+        res.addAll(Arrays.asList(interfaces));
+
+        for (Class<?> interfaze : interfaces) {
+          res.addAll(getAllExtendedOrImplementedTypesRecursively(interfaze));
+        }
+      }
+
+      // Add the super class
+      Class<?> superClass = clazz.getSuperclass();
+
+      // Interfaces does not have java,lang.Object as superclass, they have null, so break the cycle and return
+      if (superClass == null) {
+        break;
+      }
+
+      // Now inspect the superclass
+      clazz = superClass;
+    } while (!"java.lang.Object".equals(clazz.getCanonicalName()));
+
+    return new HashSet<Class<?>>(res);
+  }
+}

--- a/core/src/main/java/org/modelmapper/internal/ExplicitMappingBuilder.java
+++ b/core/src/main/java/org/modelmapper/internal/ExplicitMappingBuilder.java
@@ -28,10 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.MethodInterceptor;
-import net.sf.cglib.proxy.MethodProxy;
-
 import org.modelmapper.Condition;
 import org.modelmapper.ConfigurationException;
 import org.modelmapper.Converter;
@@ -48,9 +44,13 @@ import org.modelmapper.spi.PropertyType;
 import org.modelmapper.spi.ValueReader;
 import org.objectweb.asm.ClassReader;
 
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.MethodProxy;
+
 /**
  * Builds explicit property mappings.
- * 
+ *
  * @author Jonathan Halterman
  */
 public class ExplicitMappingBuilder<S, D> implements ConditionExpression<S, D> {
@@ -299,7 +299,7 @@ public class ExplicitMappingBuilder<S, D> implements ConditionExpression<S, D> {
     ExplicitMappingInterceptor interceptor = new ExplicitMappingInterceptor();
 
     try {
-      T proxy = ProxyFactory.proxyFor(type, interceptor, proxyErrors);
+      T proxy = ProxyFactory.proxyFor(type, interceptor, proxyErrors, configuration.isUseOSGiClassLoaderBridging());
       proxyInterceptors.put(proxy, interceptor);
       return proxy;
     } catch (ErrorsException e) {

--- a/core/src/main/java/org/modelmapper/internal/InheritingConfiguration.java
+++ b/core/src/main/java/org/modelmapper/internal/InheritingConfiguration.java
@@ -36,7 +36,7 @@ import org.modelmapper.spi.ValueReader;
 
 /**
  * Inheritable mapping configuration implementation.
- * 
+ *
  * @author Jonathan Halterman
  */
 public class InheritingConfiguration implements Configuration {
@@ -60,6 +60,7 @@ public class InheritingConfiguration implements Configuration {
   private Boolean fullTypeMatchingRequired;
   private Boolean implicitMatchingEnabled;
   private Boolean skipNullEnabled;
+  private Boolean useOSGiClassLoaderBridging;
 
   /**
    * Creates an initial InheritingConfiguration.
@@ -83,6 +84,7 @@ public class InheritingConfiguration implements Configuration {
     fullTypeMatchingRequired = Boolean.FALSE;
     implicitMatchingEnabled = Boolean.TRUE;
     skipNullEnabled = Boolean.FALSE;
+    useOSGiClassLoaderBridging = Boolean.FALSE;
   }
 
   /**
@@ -246,6 +248,11 @@ public class InheritingConfiguration implements Configuration {
         : skipNullEnabled;
   }
 
+  public boolean isUseOSGiClassLoaderBridging() {
+    return useOSGiClassLoaderBridging == null ? parent.isUseOSGiClassLoaderBridging()
+        : useOSGiClassLoaderBridging;
+  }
+
   public Configuration setAmbiguityIgnored(boolean ignore) {
     this.ambiguityIgnored = ignore;
     return this;
@@ -323,6 +330,11 @@ public class InheritingConfiguration implements Configuration {
 
   public Configuration setSourceNamingConvention(NamingConvention namingConvention) {
     sourceNamingConvention = Assert.notNull(namingConvention);
+    return this;
+  }
+
+  public Configuration setUseOSGiClassLoaderBridging(boolean useOSGiClassLoaderBridging) {
+    this.useOSGiClassLoaderBridging = useOSGiClassLoaderBridging;
     return this;
   }
 }

--- a/core/src/main/java/org/modelmapper/internal/ProxyFactory.java
+++ b/core/src/main/java/org/modelmapper/internal/ProxyFactory.java
@@ -19,6 +19,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+import org.modelmapper.internal.util.Primitives;
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
+
 import net.sf.cglib.core.DefaultNamingPolicy;
 import net.sf.cglib.core.NamingPolicy;
 import net.sf.cglib.proxy.CallbackFilter;
@@ -26,13 +30,9 @@ import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.MethodInterceptor;
 import net.sf.cglib.proxy.NoOp;
 
-import org.modelmapper.internal.util.Primitives;
-import org.objenesis.Objenesis;
-import org.objenesis.ObjenesisStd;
-
 /**
  * Produces proxied instances of mappable types that participate in mapping creation.
- * 
+ *
  * @author Jonathan Halterman
  */
 class ProxyFactory {
@@ -55,8 +55,10 @@ class ProxyFactory {
     }
   };
 
-  static Class<?> proxyClassFor(Class<?> type, Errors errors) throws ErrorsException {
+  static Class<?> proxyClassFor(Class<?> type, Errors errors, boolean useOSGiClassLoaderBridging) throws ErrorsException {
     Enhancer enhancer = new Enhancer();
+    if (useOSGiClassLoaderBridging)
+      enhancer.setClassLoader(BridgeClassLoaderFactory.getClassLoader(type));
     enhancer.setSuperclass(type);
     enhancer.setUseFactory(true);
     enhancer.setUseCache(true);
@@ -74,15 +76,23 @@ class ProxyFactory {
   /**
    * @throws ErrorsException if the proxy for {@code type} cannot be generated or instantiated
    */
-  @SuppressWarnings("unchecked")
   static <T> T proxyFor(Class<T> type, MethodInterceptor interceptor, Errors errors)
+      throws ErrorsException {
+    return proxyFor(type, interceptor, errors, Boolean.FALSE);
+  }
+
+  /**
+   * @throws ErrorsException if the proxy for {@code type} cannot be generated or instantiated
+   */
+  @SuppressWarnings("unchecked")
+  static <T> T proxyFor(Class<T> type, MethodInterceptor interceptor, Errors errors, boolean useOSGiClassLoaderBridging)
       throws ErrorsException {
     if (Primitives.isPrimitive(type))
       return Primitives.defaultValueForWrapper(type);
     if (Modifier.isFinal(type.getModifiers()))
       throw errors.invocationAgainstFinalClass(type).toException();
 
-    Class<?> enhanced = proxyClassFor(type, errors);
+    Class<?> enhanced = proxyClassFor(type, errors, useOSGiClassLoaderBridging);
 
     try {
       T result = (T) OBJENESIS.newInstance(enhanced);


### PR DESCRIPTION
Creating a new PR on top of my first one:
https://github.com/modelmapper/modelmapper/pull/286

The idea here is to apply the OSGi Class Loader Bridge approach that is described here:
https://www.infoq.com/articles/code-generation-with-osgi

This eliminates the need to define explicit OSGi imports to the cglib classes in user's bundles.
In addition to that, it attempts to solve the issue described here:
https://stackoverflow.com/questions/47854086/cglib-creating-class-proxy-in-osgi-results-in-noclassdeffounderror
The idea is to keep track of class loaders of class types that are found in the parent type hierarchy of the user's type. We can later use these class loaders as fallback for loading types that are otherwise unknown to the Bundle's class loader of the user's type.