### PR TITLE
XMLGregorianCalendar to Long converter

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/converter/NumberConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/NumberConverter.java
@@ -25,6 +25,8 @@ import org.modelmapper.internal.util.Primitives;
 import org.modelmapper.spi.ConditionalConverter;
 import org.modelmapper.spi.MappingContext;
 
+import javax.xml.datatype.XMLGregorianCalendar;
+
 /**
  * Converts:
  * 
@@ -68,6 +70,8 @@ class NumberConverter implements ConditionalConverter<Object, Number> {
       return Long.valueOf(((Date) source).getTime());
     if (source instanceof Calendar && Long.class.equals(destinationType))
       return Long.valueOf(((Calendar) source).getTime().getTime());
+    if (source instanceof XMLGregorianCalendar && Long.class.equals(destinationType))
+      return ((XMLGregorianCalendar) source).toGregorianCalendar().getTimeInMillis();
     return numberFor(source.toString(), destinationType);
   }
 
@@ -77,7 +81,8 @@ class NumberConverter implements ConditionalConverter<Object, Number> {
       return Number.class.isAssignableFrom(Primitives.wrapperFor(sourceType))
           || sourceType == Boolean.class || sourceType == Boolean.TYPE
           || sourceType == String.class || Date.class.isAssignableFrom(sourceType)
-          || Calendar.class.isAssignableFrom(sourceType) ? MatchResult.FULL : MatchResult.PARTIAL;
+          || Calendar.class.isAssignableFrom(sourceType)
+          || XMLGregorianCalendar.class.isAssignableFrom(sourceType) ? MatchResult.FULL : MatchResult.PARTIAL;
     } else
       return MatchResult.NONE;
   }

--- a/core/src/test/java/org/modelmapper/internal/converter/NumberConverterTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/NumberConverterTest.java
@@ -21,11 +21,15 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 
 import org.modelmapper.MappingException;
 import org.modelmapper.spi.ConditionalConverter.MatchResult;
@@ -120,6 +124,12 @@ public class NumberConverterTest extends AbstractConverterTest {
   public void shouldConvertDateToLong() {
     Date dateValue = new Date();
     assertEquals(new Long(dateValue.getTime()), convert(dateValue, Long.class));
+  }
+
+  @Test
+  public void shouldConvertXmlGregorianCalendarToLong() throws DatatypeConfigurationException {
+    XMLGregorianCalendar xmlGregorianCalendar = DatatypeFactory.newInstance().newXMLGregorianCalendar(new GregorianCalendar());
+    assertEquals(xmlGregorianCalendar.toGregorianCalendar().getTimeInMillis(), convert(xmlGregorianCalendar, Long.class));
   }
 
   public void shouldConvertDoubles() {
@@ -328,7 +338,7 @@ public class NumberConverterTest extends AbstractConverterTest {
     Class<?>[] sourceTypes = { Byte.class, Byte.TYPE, Short.class, Short.TYPE, Integer.class,
         Integer.TYPE, Long.class, Long.TYPE, Float.class, Float.TYPE, Double.class, Double.TYPE,
         BigDecimal.class, BigInteger.class, Boolean.class, Boolean.TYPE, Date.class,
-        Calendar.class, String.class };
+        Calendar.class, String.class, XMLGregorianCalendar.class };
     Class<?>[] destinationTypes = { Byte.class, Byte.TYPE, Short.class, Short.TYPE, Integer.class,
         Integer.TYPE, Long.class, Long.TYPE, Float.class, Float.TYPE, Double.class, Double.TYPE,
         BigDecimal.class, BigInteger.class };


### PR DESCRIPTION
It would be nice feature to convert the `XMLGregorianCalendar` to `Long` time from epoch milliseconds as the `CalendarConverter` do. 

Because the `modelmapper` uses the first converter to convert the field, the `NumberConverter` will do this and currently it throws an exception, because it tries to call `numberFor(source.toString(), destinationType)`
