### PR TITLE
In order to use ModelMapper in jdk11 (build 11+28).

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,11 +12,11 @@
   <name>ModelMapper</name>
 
   <properties>
-    <cglib.version>3.2.6</cglib.version>
-    <asm.version>6.1.1</asm.version>
+    <cglib.version>3.2.8</cglib.version>
+    <asm.version>6.2.1</asm.version>
     <objenesis.version>2.6</objenesis.version>
     <typetools.version>0.5.0</typetools.version>
-    <bytebuddy.version>1.8.3</bytebuddy.version>
+    <bytebuddy.version>1.8.22</bytebuddy.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Bump up library dependencies for

1) ByteBuddy from 1.8.3 to 1.8.22
2) ASM       from 6.1.1 to 6.2.1
3) Cglib     from 3.2.6 to 3.2.8

Also added usage of `ClassLoadingStrategy` for `load()` method when using
ByteBuddy, which is recommended by the author of the ByteBuddy library
here: https://github.com/raphw/byte-buddy/issues/447

