### PR TITLE
Fix OSGI Imports required by internal packages: Fixes(#401)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -198,7 +198,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>
@@ -242,7 +242,7 @@
             </goals>
             <configuration>
               <archive>
-                <manifestFile>target/classes/META-INF/MANIFEST.MF</manifestFile>
+                <manifestFile>${project.build.directory}/classes/META-INF/MANIFEST.MF</manifestFile>
               </archive>
             </configuration>
           </execution>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -173,12 +173,36 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.5.0</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>process-classes</phase>
+            <id>unpack-shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <version>${project.version}</version>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}/classes</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>package</phase>
             <goals>
               <goal>manifest</goal>
             </goals>
@@ -194,22 +218,35 @@
               org.modelmapper.convention,
               org.modelmapper.spi
             </Export-Package>
-            <Import-Package>
-              javax.xml.datatype
-            </Import-Package>
             <Private-Package>
-              org.modelmapper.internal.*
+              org.modelmapper.internal.**
             </Private-Package>
           </instructions>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>package-pre-shaded</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>package-bundle</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifestFile>target/classes/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Reverted the change to the build introduced by f0202484806ff039cb7ffbd24cfd3da58480c009 to execute the bundle plugin on the unpacked shaded jar to ensure all classes including internal are examined for imports by the bnd plugin.

