### PR TITLE
Fix NoSuchElementException when iterating through Collection interface using iterator

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/util/Iterables.java
+++ b/core/src/main/java/org/modelmapper/internal/util/Iterables.java
@@ -110,7 +110,7 @@ public final class Iterables {
       return ((List<Object>) collection).get(index);
 
     Iterator<Object> iterator = collection.iterator();
-    for (int i = 0; i <= index; i++) {
+    for (int i = 0; i < index; i++) {
       iterator.next();
     }
     return iterator.next();

--- a/core/src/test/java/org/modelmapper/internal/util/IterablesTest.java
+++ b/core/src/test/java/org/modelmapper/internal/util/IterablesTest.java
@@ -1,0 +1,31 @@
+package org.modelmapper.internal.util;
+
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class IterablesTest {
+
+    public void shouldGetFirstIndexFromSet() {
+        Collection<Object> collection = new HashSet<Object>();
+        String testValue = "test value";
+        collection.add(testValue);
+
+        assertEquals(Iterables.getElementFromCollection(collection, 0), testValue);
+    }
+
+    public void shouldGetLastIndexFromSet() {
+        Collection<Object> collection = new LinkedHashSet<Object>();
+        String testValue = "test value";
+        collection.add(testValue);
+        String lastTestValue = "last test value";
+        collection.add(lastTestValue);
+
+        assertEquals(Iterables.getElementFromCollection(collection, collection.size() - 1), lastTestValue);
+    }
+}


### PR DESCRIPTION
Hello,

I have recently found, that when you try to map elements from collection, which does not implement List interface, into another this raises NoSuchElementBug. It happens in the below fragment:

```
  public static Object getElementFromCollection(Collection<Object> collection, int index) {
    if (collection.size() < index + 1)
      return null;

    if (collection instanceof List)
      return ((List<Object>) collection).get(index);

    Iterator<Object> iterator = collection.iterator();
    for (int i = 0; i <= index; i++) {
      iterator.next();
    }
    return iterator.next();
  }
```
  
 This method, when called with HashSet containing only one element and index=0 throws NoSuchElementException because it calls `iterator.next();` too many times. I have stumbled upon this bug when trying to map one Set to another, like that:
 
```
 Set<String> source = new HashSet<>();
 source.add("test value")
 
 Set<String> dest = new HashSet<>();
 dest.add("destination test value")
 
 modelMapper.map(source, destination);
```
 
 What is also worth noting is that the error message was quite ambigious - 

> Could not map hash java.util.Set to java.util.Set

 but I can't find where the error messages are generated. 

Please let me know whether this solution fits your needs.