### PR TITLE
add to AbstractConverter method map to allow use another converters f…

### DIFF
--- a/core/src/main/java/org/modelmapper/AbstractConverter.java
+++ b/core/src/main/java/org/modelmapper/AbstractConverter.java
@@ -31,37 +31,37 @@ import org.modelmapper.spi.MappingContext;
  */
 public abstract class AbstractConverter<S, D> implements Converter<S, D> {
 
-    private MappingEngineImpl mappingEngine;
+  private MappingEngineImpl mappingEngine;
 
-    /**
-     * Delegates conversion to {@link #convert(Object)}.
-     */
-    public D convert(MappingContext<S, D> context) {
-        if (mappingEngine == null) {
-            mappingEngine = (MappingEngineImpl) context.getMappingEngine();
-        }
-        return convert(context.getSource());
+  /**
+   * Delegates conversion to {@link #convert(Object)}.
+   */
+  public D convert(MappingContext<S, D> context) {
+    if (mappingEngine == null) {
+      mappingEngine = (MappingEngineImpl) context.getMappingEngine();
     }
+    return convert(context.getSource());
+  }
 
-    @Override
-    public String toString() {
-        return String.format("Converter<%s, %s>",
-                (Object[]) TypeResolver.resolveRawArguments(Converter.class, getClass()));
-    }
+  @Override
+  public String toString() {
+    return String.format("Converter<%s, %s>",
+            (Object[]) TypeResolver.resolveRawArguments(Converter.class, getClass()));
+  }
 
-    /**
-     * Converts {@code source} to an instance of type {@code D}.
-     */
-    protected abstract D convert(S source);
+  /**
+   * Converts {@code source} to an instance of type {@code D}.
+   */
+  protected abstract D convert(S source);
 
-    /**
-     * @param source          - source object
-     * @param destinationType - destination class
-     */
-    protected <Destination> Destination map(Object source, Class<Destination> destinationType) {
-        Assert.notNull(source, "source");
-        Assert.notNull(destinationType, "destinationType");
-        Assert.notNull(mappingEngine, "mappingEngine");
-        return this.mappingEngine.map(source, Types.deProxy(source.getClass()), null, TypeToken.<Destination>of(destinationType), null);
-    }
+  /**
+   * @param source          - source object
+   * @param destinationType - destination class
+   */
+  protected <Destination> Destination map(Object source, Class<Destination> destinationType) {
+    Assert.notNull(source, "source");
+    Assert.notNull(destinationType, "destinationType");
+    Assert.notNull(mappingEngine, "mappingEngine");
+    return this.mappingEngine.map(source, Types.deProxy(source.getClass()), null, TypeToken.<Destination>of(destinationType), null);
+  }
 }

--- a/core/src/main/java/org/modelmapper/AbstractConverter.java
+++ b/core/src/main/java/org/modelmapper/AbstractConverter.java
@@ -16,32 +16,52 @@
 package org.modelmapper;
 
 import net.jodah.typetools.TypeResolver;
+import org.modelmapper.internal.MappingEngineImpl;
+import org.modelmapper.internal.util.Assert;
+import org.modelmapper.internal.util.Types;
 import org.modelmapper.spi.MappingContext;
 
 /**
  * Converter support class. Allows for simpler Converter implementations.
- * 
+ *
  * @param <S> source type
  * @param <D> destination type
- * 
+ *
  * @author Jonathan Halterman
  */
 public abstract class AbstractConverter<S, D> implements Converter<S, D> {
-  /**
-   * Delegates conversion to {@link #convert(Object)}.
-   */
-  public D convert(MappingContext<S, D> context) {
-    return convert(context.getSource());
-  }
 
-  @Override
-  public String toString() {
-    return String.format("Converter<%s, %s>",
-        (Object[]) TypeResolver.resolveRawArguments(Converter.class, getClass()));
-  }
+    private MappingEngineImpl mappingEngine;
 
-  /**
-   * Converts {@code source} to an instance of type {@code D}.
-   */
-  protected abstract D convert(S source);
+    /**
+     * Delegates conversion to {@link #convert(Object)}.
+     */
+    public D convert(MappingContext<S, D> context) {
+        if (mappingEngine == null) {
+            mappingEngine = (MappingEngineImpl) context.getMappingEngine();
+        }
+        return convert(context.getSource());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Converter<%s, %s>",
+                (Object[]) TypeResolver.resolveRawArguments(Converter.class, getClass()));
+    }
+
+    /**
+     * Converts {@code source} to an instance of type {@code D}.
+     */
+    protected abstract D convert(S source);
+
+    /**
+     * @param source          - source object
+     * @param destinationType - destination class
+     */
+    protected <Destination> Destination map(Object source, Class<Destination> destinationType) {
+        Assert.notNull(source, "source");
+        Assert.notNull(destinationType, "destinationType");
+        Assert.notNull(mappingEngine, "mappingEngine");
+        return this.mappingEngine.map(source, Types.deProxy(source.getClass()), null, TypeToken.<Destination>of(destinationType), null);
+    }
 }

--- a/core/src/test/java/org/modelmapper/internal/converter/AbstractConverterFeatureTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/AbstractConverterFeatureTest.java
@@ -1,0 +1,68 @@
+package org.modelmapper.internal.converter;
+
+
+import org.modelmapper.AbstractConverter;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.internal.InheritingConfiguration;
+import org.modelmapper.internal.MappingEngineImpl;
+import org.modelmapper.internal.converter.dto.ChildDTO;
+import org.modelmapper.internal.converter.dto.ChildEntity;
+import org.modelmapper.internal.converter.dto.ParentDTO;
+import org.modelmapper.internal.converter.dto.ParentEntity;
+import org.modelmapper.spi.MappingEngine;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AbstractConverterFeatureTest {
+
+    protected ModelMapper modelMapper;
+    protected InheritingConfiguration config = new InheritingConfiguration();
+    private MappingEngine engine = new MappingEngineImpl(config);
+
+    @BeforeMethod
+    protected void init() {
+        modelMapper = new ModelMapper();
+        modelMapper.addConverter(new ParentConverter());
+        modelMapper.addConverter(new ChildConverter());
+    }
+
+
+    @Test
+    public void testConverterFeature() {
+        ParentEntity entity = getParentTest();
+        ParentDTO dto = modelMapper.map(entity, ParentDTO.class);
+        Assert.assertEquals(dto.getName(), entity.getName());
+        Assert.assertEquals(dto.getSecondName(), entity.getSecondName());
+        Assert.assertEquals(dto.getChild().getChildName(), entity.getChild().getName());
+
+    }
+
+
+    private ParentEntity getParentTest() {
+        return new ParentEntity("parent", "second", new ChildEntity("child"));
+    }
+
+    private class ParentConverter extends AbstractConverter<ParentEntity, ParentDTO> {
+
+        @Override
+        protected ParentDTO convert(ParentEntity source) {
+            ParentDTO dto = new ParentDTO();
+            dto.setSecondName(source.getSecondName());
+            dto.setName(source.getName());
+            dto.setChild(map(source.getChild(), ChildDTO.class));
+            return dto;
+        }
+    }
+
+    private class ChildConverter extends AbstractConverter<ChildEntity, ChildDTO> {
+        @Override
+        protected ChildDTO convert(ChildEntity source) {
+            ChildDTO dto = new ChildDTO();
+            dto.setChildName(source.getName());
+            return dto;
+        }
+    }
+
+
+}

--- a/core/src/test/java/org/modelmapper/internal/converter/AbstractConverterFeatureTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/AbstractConverterFeatureTest.java
@@ -16,53 +16,53 @@ import org.testng.annotations.Test;
 
 public class AbstractConverterFeatureTest {
 
-    protected ModelMapper modelMapper;
-    protected InheritingConfiguration config = new InheritingConfiguration();
-    private MappingEngine engine = new MappingEngineImpl(config);
+  protected ModelMapper modelMapper;
+  protected InheritingConfiguration config = new InheritingConfiguration();
+  private MappingEngine engine = new MappingEngineImpl(config);
 
-    @BeforeMethod
-    protected void init() {
-        modelMapper = new ModelMapper();
-        modelMapper.addConverter(new ParentConverter());
-        modelMapper.addConverter(new ChildConverter());
+  @BeforeMethod
+  protected void init() {
+    modelMapper = new ModelMapper();
+    modelMapper.addConverter(new ParentConverter());
+    modelMapper.addConverter(new ChildConverter());
+  }
+
+
+  @Test
+  public void testConverterFeature() {
+    ParentEntity entity = getParentTest();
+    ParentDTO dto = modelMapper.map(entity, ParentDTO.class);
+    Assert.assertEquals(dto.getName(), entity.getName());
+    Assert.assertEquals(dto.getSecondName(), entity.getSecondName());
+    Assert.assertEquals(dto.getChild().getChildName(), entity.getChild().getName());
+
+  }
+
+
+  private ParentEntity getParentTest() {
+    return new ParentEntity("parent", "second", new ChildEntity("child"));
+  }
+
+  private class ParentConverter extends AbstractConverter<ParentEntity, ParentDTO> {
+
+    @Override
+    protected ParentDTO convert(ParentEntity source) {
+      ParentDTO dto = new ParentDTO();
+      dto.setSecondName(source.getSecondName());
+      dto.setName(source.getName());
+      dto.setChild(map(source.getChild(), ChildDTO.class));
+      return dto;
     }
+  }
 
-
-    @Test
-    public void testConverterFeature() {
-        ParentEntity entity = getParentTest();
-        ParentDTO dto = modelMapper.map(entity, ParentDTO.class);
-        Assert.assertEquals(dto.getName(), entity.getName());
-        Assert.assertEquals(dto.getSecondName(), entity.getSecondName());
-        Assert.assertEquals(dto.getChild().getChildName(), entity.getChild().getName());
-
+  private class ChildConverter extends AbstractConverter<ChildEntity, ChildDTO> {
+    @Override
+    protected ChildDTO convert(ChildEntity source) {
+      ChildDTO dto = new ChildDTO();
+      dto.setChildName(source.getName());
+      return dto;
     }
-
-
-    private ParentEntity getParentTest() {
-        return new ParentEntity("parent", "second", new ChildEntity("child"));
-    }
-
-    private class ParentConverter extends AbstractConverter<ParentEntity, ParentDTO> {
-
-        @Override
-        protected ParentDTO convert(ParentEntity source) {
-            ParentDTO dto = new ParentDTO();
-            dto.setSecondName(source.getSecondName());
-            dto.setName(source.getName());
-            dto.setChild(map(source.getChild(), ChildDTO.class));
-            return dto;
-        }
-    }
-
-    private class ChildConverter extends AbstractConverter<ChildEntity, ChildDTO> {
-        @Override
-        protected ChildDTO convert(ChildEntity source) {
-            ChildDTO dto = new ChildDTO();
-            dto.setChildName(source.getName());
-            return dto;
-        }
-    }
+  }
 
 
 }

--- a/core/src/test/java/org/modelmapper/internal/converter/dto/ChildDTO.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/dto/ChildDTO.java
@@ -1,0 +1,14 @@
+package org.modelmapper.internal.converter.dto;
+
+public class ChildDTO {
+
+    private String childName;
+
+    public String getChildName() {
+        return childName;
+    }
+
+    public void setChildName(String childName) {
+        this.childName = childName;
+    }
+}

--- a/core/src/test/java/org/modelmapper/internal/converter/dto/ChildDTO.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/dto/ChildDTO.java
@@ -2,13 +2,13 @@ package org.modelmapper.internal.converter.dto;
 
 public class ChildDTO {
 
-    private String childName;
+  private String childName;
 
-    public String getChildName() {
-        return childName;
-    }
+  public String getChildName() {
+    return childName;
+  }
 
-    public void setChildName(String childName) {
-        this.childName = childName;
-    }
+  public void setChildName(String childName) {
+    this.childName = childName;
+  }
 }

--- a/core/src/test/java/org/modelmapper/internal/converter/dto/ChildEntity.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/dto/ChildEntity.java
@@ -1,0 +1,22 @@
+package org.modelmapper.internal.converter.dto;
+
+public class ChildEntity {
+
+    private String name;
+
+    public ChildEntity() {
+    }
+
+    public ChildEntity(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/core/src/test/java/org/modelmapper/internal/converter/dto/ChildEntity.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/dto/ChildEntity.java
@@ -2,21 +2,21 @@ package org.modelmapper.internal.converter.dto;
 
 public class ChildEntity {
 
-    private String name;
+  private String name;
 
-    public ChildEntity() {
-    }
+  public ChildEntity() {
+  }
 
-    public ChildEntity(String name) {
-        this.name = name;
-    }
+  public ChildEntity(String name) {
+    this.name = name;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
 }

--- a/core/src/test/java/org/modelmapper/internal/converter/dto/ParentDTO.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/dto/ParentDTO.java
@@ -2,31 +2,31 @@ package org.modelmapper.internal.converter.dto;
 
 public class ParentDTO {
 
-    private String name;
-    private String secondName;
-    private ChildDTO child;
+  private String name;
+  private String secondName;
+  private ChildDTO child;
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    public String getSecondName() {
-        return secondName;
-    }
+  public String getSecondName() {
+    return secondName;
+  }
 
-    public void setSecondName(String secondName) {
-        this.secondName = secondName;
-    }
+  public void setSecondName(String secondName) {
+    this.secondName = secondName;
+  }
 
-    public ChildDTO getChild() {
-        return child;
-    }
+  public ChildDTO getChild() {
+    return child;
+  }
 
-    public void setChild(ChildDTO child) {
-        this.child = child;
-    }
+  public void setChild(ChildDTO child) {
+    this.child = child;
+  }
 }

--- a/core/src/test/java/org/modelmapper/internal/converter/dto/ParentDTO.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/dto/ParentDTO.java
@@ -1,0 +1,32 @@
+package org.modelmapper.internal.converter.dto;
+
+public class ParentDTO {
+
+    private String name;
+    private String secondName;
+    private ChildDTO child;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSecondName() {
+        return secondName;
+    }
+
+    public void setSecondName(String secondName) {
+        this.secondName = secondName;
+    }
+
+    public ChildDTO getChild() {
+        return child;
+    }
+
+    public void setChild(ChildDTO child) {
+        this.child = child;
+    }
+}

--- a/core/src/test/java/org/modelmapper/internal/converter/dto/ParentEntity.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/dto/ParentEntity.java
@@ -1,0 +1,42 @@
+package org.modelmapper.internal.converter.dto;
+
+public class ParentEntity {
+
+    private String name;
+    private String secondName;
+    private ChildEntity child;
+
+    public ParentEntity() {
+    }
+
+    public ParentEntity(String name, String secondName, ChildEntity child) {
+        this.name = name;
+        this.secondName = secondName;
+        this.child = child;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSecondName() {
+        return secondName;
+    }
+
+    public void setSecondName(String secondName) {
+        this.secondName = secondName;
+    }
+
+    public ChildEntity getChild() {
+        return child;
+    }
+
+    public void setChild(ChildEntity child) {
+        this.child = child;
+    }
+
+}

--- a/core/src/test/java/org/modelmapper/internal/converter/dto/ParentEntity.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/dto/ParentEntity.java
@@ -2,41 +2,41 @@ package org.modelmapper.internal.converter.dto;
 
 public class ParentEntity {
 
-    private String name;
-    private String secondName;
-    private ChildEntity child;
+  private String name;
+  private String secondName;
+  private ChildEntity child;
 
-    public ParentEntity() {
-    }
+  public ParentEntity() {
+  }
 
-    public ParentEntity(String name, String secondName, ChildEntity child) {
-        this.name = name;
-        this.secondName = secondName;
-        this.child = child;
-    }
+  public ParentEntity(String name, String secondName, ChildEntity child) {
+    this.name = name;
+    this.secondName = secondName;
+    this.child = child;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    public String getSecondName() {
-        return secondName;
-    }
+  public String getSecondName() {
+    return secondName;
+  }
 
-    public void setSecondName(String secondName) {
-        this.secondName = secondName;
-    }
+  public void setSecondName(String secondName) {
+    this.secondName = secondName;
+  }
 
-    public ChildEntity getChild() {
-        return child;
-    }
+  public ChildEntity getChild() {
+    return child;
+  }
 
-    public void setChild(ChildEntity child) {
-        this.child = child;
-    }
+  public void setChild(ChildEntity child) {
+    this.child = child;
+  }
 
 }


### PR DESCRIPTION
In many use cases when use modelMapper in converter need access to MappingEngineImpl for re use already present converters.
But it not comfortable to use in converters this structure 
`mappingEngine.map(source, Types.deProxy(source.getClass()), null, TypeToken.<Destination>of(destinationType), null)`
I think it will be useful feature when you can to reuse registered converters in any converter just using 
`map(Object source, Class<Destination> destinationType)`