### PR TITLE
Fixed invalid property info return on hash collision

### DIFF
--- a/core/src/test/java/org/modelmapper/internal/PropertyInfoRegistryTest.java
+++ b/core/src/test/java/org/modelmapper/internal/PropertyInfoRegistryTest.java
@@ -27,6 +27,16 @@ public class PropertyInfoRegistryTest extends AbstractTest {
     }
   }
 
+  static class ForHashCollision {
+    public String AaAa() {
+      return "HashCode of 'AaAa' string equals 'BBBB'";
+    }
+
+    public String BBBB() {
+      return "HashCode of 'BBBB' string equals 'AaAa'";
+    }
+  }
+
   public void shouldResolveSeparatePropertyInfoForDifferentInitialTypes() throws Exception {
     Method getId = Entity.class.getMethod("getId");
     Accessor longGetId = PropertyInfoRegistry.accessorFor(LongEntity.class, getId,
@@ -49,5 +59,17 @@ public class PropertyInfoRegistryTest extends AbstractTest {
         modelMapper.getConfiguration(), "getId");
 
     assertTrue(longGetId1 == longGetId2);
+  }
+
+  public void shouldOvercomeHashCollision() throws Exception {
+    // "AaAa".hashCode() == "BBBB".hashCode()
+    Method methodAaAa = ForHashCollision.class.getMethod("AaAa");
+    Method methodBBBB = ForHashCollision.class.getMethod("BBBB");
+    final Accessor accessorAaAa = PropertyInfoRegistry.accessorFor(ForHashCollision.class,
+        methodAaAa, modelMapper.getConfiguration(), methodAaAa.getName());
+    final Accessor accessorBBBB = PropertyInfoRegistry.accessorFor(ForHashCollision.class,
+        methodBBBB, modelMapper.getConfiguration(), methodBBBB.getName());
+
+    assertFalse(accessorAaAa.equals(accessorBBBB));
   }
 }


### PR DESCRIPTION
ModelMapper sometimes tries to map wrong property. I logged `TypeMapStore`'s `typeMaps` field and it looks as follows.

```
...
codehumane.Source -> codehumane.Destination
  PropertyMapping[Source.name -> Destination.name]
  PropertyMapping[Source.age -> Destination.age]
  PropertyMapping[Hello.hi -> Destination.sex] // invalid mapping here!
  PropertyMapping[Source.phone -> Destination.phone]
...
```

I looked a little further and I think `PropertyInfoRegistry#hashCodeFor` is the problem.

1. Sometimes `hashCodeFor` returns same value for different properties.
2. Then `PropertyInfoRegistry` stores just one property and ignores others.

So, I create `PropertyInfoKey` to use as a cache key instead of `Integer` to resolve hash collision.

All tests are green. And I hope this is all right. Thanks!