### PR TITLE
 Provide destinationPath in error messages for Mapping, Convert, Set, Instantiate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ release.properties
 .settings/
 _site/
 user-manual/
+.idea/
+*.iml
+

--- a/core/src/main/java/org/modelmapper/internal/Errors.java
+++ b/core/src/main/java/org/modelmapper/internal/Errors.java
@@ -179,12 +179,14 @@ public final class Errors {
         type, type);
   }
 
-  public Errors errorMapping(Object source, Class<?> destinationType) {
-    return addMessage("Error mapping %s to %s", source, Types.toString(destinationType));
+  public Errors errorMapping(Object source, Class<?> destinationType, String destinationPath) {
+    String destinationInfo = destinationPath.isEmpty() ? "" : ", destination path: " + destinationPath;
+    return addMessage("Error mapping %s%s", source, Types.toString(destinationType), destinationInfo);
   }
 
-  public Errors errorMapping(Object source, Type destinationType, Throwable t) {
-    return addMessage(t, "Error mapping %s to %s", source, Types.toString(destinationType));
+  public Errors errorMapping(Object source, Type destinationType, String destinationPath, Throwable t) {
+    String destinationInfo = destinationPath.isEmpty() ? "" : ", destination path: " + destinationPath;
+    return addMessage(t, "Error mapping %s to %s%s", source, Types.toString(destinationType), destinationInfo);
   }
 
   public Errors errorSettingValue(Member member, Object value, Throwable t) {

--- a/core/src/main/java/org/modelmapper/internal/Errors.java
+++ b/core/src/main/java/org/modelmapper/internal/Errors.java
@@ -172,11 +172,12 @@ public final class Errors {
     return addMessage(t, "Failed to get value from %s", member);
   }
 
-  public Errors errorInstantiatingDestination(Class<?> type, Throwable t) {
+  public Errors errorInstantiatingDestination(Class<?> type, String destinationPath, Throwable t) {
+    String destinationInfo = destinationPath.isEmpty() ? "" : " Destination path: " + destinationPath;
     return addMessage(
         t,
-        "Failed to instantiate instance of destination %s. Ensure that %s has a non-private no-argument constructor.",
-        type, type);
+        "Failed to instantiate instance of destination %s. Ensure that %s has a non-private no-argument constructor.%s",
+        type, type, destinationInfo);
   }
 
   public Errors errorMapping(Object source, Class<?> destinationType, String destinationPath) {

--- a/core/src/main/java/org/modelmapper/internal/Errors.java
+++ b/core/src/main/java/org/modelmapper/internal/Errors.java
@@ -190,8 +190,9 @@ public final class Errors {
     return addMessage(t, "Error mapping %s to %s%s", source, Types.toString(destinationType), destinationInfo);
   }
 
-  public Errors errorSettingValue(Member member, Object value, Throwable t) {
-    return addMessage(t, "Failed to set value '%s' on %s", value, member);
+  public Errors errorSettingValue(Member member, Object value, String destinationPath, Throwable t) {
+    String destinationInfo = destinationPath.isEmpty() ? "" : ", destination path: " + destinationPath;
+    return addMessage(t, "Failed to set value '%s' on %s%s", value, member, destinationInfo);
   }
 
   public Errors errorTooLarge(Object source, Class<?> destinationType) {

--- a/core/src/main/java/org/modelmapper/internal/ExplicitMappingBuilder.java
+++ b/core/src/main/java/org/modelmapper/internal/ExplicitMappingBuilder.java
@@ -294,7 +294,7 @@ public class ExplicitMappingBuilder<S, D> implements ConditionExpression<S, D> {
         Object nextProxy = field.getValue(proxy);
         if (nextProxy == null) {
           nextProxy = createProxy(field.getType());
-          field.setValue(proxy, nextProxy);
+          field.setValue(proxy, nextProxy, field.getName() + ".");
         }
         proxy = nextProxy;
       }

--- a/core/src/main/java/org/modelmapper/internal/MappingContextImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingContextImpl.java
@@ -321,7 +321,7 @@ public class MappingContextImpl<S, D> implements MappingContext<S, D>, Provision
         next = mappingEngine.createDestinationViaGlobalProvider(parent.parentSource, mutator.getType(), destPath, parent.errors);
 
       if (next != null) {
-        mutator.setValue(current, next);
+        mutator.setValue(current, next, destPath);
         parent.destinationCache.put(destPath, next);
       }
       current = next;

--- a/core/src/main/java/org/modelmapper/internal/MappingContextImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingContextImpl.java
@@ -185,6 +185,11 @@ public class MappingContextImpl<S, D> implements MappingContext<S, D>, Provision
   }
 
   @Override
+  public String getDestinationPath() {
+    return destinationPath;
+  }
+
+  @Override
   public Mapping getMapping() {
     return mapping;
   }

--- a/core/src/main/java/org/modelmapper/internal/MappingContextImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingContextImpl.java
@@ -318,7 +318,7 @@ public class MappingContextImpl<S, D> implements MappingContext<S, D>, Provision
           parent.getDestinationValueByType(mutator.getType()),
           parent.getDestinationValueByMemberName(current, mutator.getName()));
       if (next == null && source != null)
-        next = mappingEngine.createDestinationViaGlobalProvider(parent.parentSource, mutator.getType(), parent.errors);
+        next = mappingEngine.createDestinationViaGlobalProvider(parent.parentSource, mutator.getType(), destPath, parent.errors);
 
       if (next != null) {
         mutator.setValue(current, next);

--- a/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
@@ -328,14 +328,14 @@ public class MappingEngineImpl implements MappingEngine {
     return converter;
   }
 
-  private <T> T instantiate(Class<T> type, Errors errors) {
+  private <T> T instantiate(Class<T> type, String destinationPath, Errors errors) {
     try {
       Constructor<T> constructor = type.getDeclaredConstructor();
       if (!constructor.isAccessible())
         constructor.setAccessible(true);
       return constructor.newInstance();
     } catch (Exception e) {
-      errors.errorInstantiatingDestination(type, e);
+      errors.errorInstantiatingDestination(type, destinationPath, e);
       return null;
     }
   }
@@ -345,7 +345,7 @@ public class MappingEngineImpl implements MappingEngine {
     MappingContextImpl<S, D> contextImpl = (MappingContextImpl<S, D>) context;
     D destination = contextImpl.createDestinationViaProvider();
     if (destination == null)
-      destination = instantiate(context.getDestinationType(), contextImpl.errors);
+      destination = instantiate(context.getDestinationType(), contextImpl.getDestinationPath(), contextImpl.errors);
 
     contextImpl.setDestination(destination, true);
     return destination;
@@ -356,7 +356,7 @@ public class MappingEngineImpl implements MappingEngine {
   }
 
   @SuppressWarnings("unchecked")
-  <S, D> D createDestinationViaGlobalProvider(S source, Class<D> requestedType,
+  <S, D> D createDestinationViaGlobalProvider(S source, Class<D> requestedType, String destinationPath,
       Errors errors) {
     D destination = null;
     Provider<D> provider = (Provider<D>) configuration.getProvider();
@@ -365,7 +365,7 @@ public class MappingEngineImpl implements MappingEngine {
       validateDestination(requestedType, destination, errors);
     }
     if (destination == null)
-      destination = instantiate(requestedType, errors);
+      destination = instantiate(requestedType, destinationPath, errors);
 
     return destination;
   }

--- a/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
@@ -75,7 +75,7 @@ public class MappingEngineImpl implements MappingEngine {
     } catch (ErrorsException e) {
       throw context.errors.toMappingException();
     } catch (Throwable t) {
-      context.errors.errorMapping(sourceType, destinationTypeToken.getType(), t);
+      context.errors.errorMapping(sourceType, destinationTypeToken.getType(), context.getDestinationPath(), t);
     }
 
     context.errors.throwMappingExceptionIfErrorsExist();

--- a/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
@@ -250,7 +250,8 @@ public class MappingEngineImpl implements MappingEngine {
     if (destinationValue != null || !configuration.isSkipNullEnabled())
       mutator.setValue(destination,
           destinationValue == null ? Primitives.defaultValue(mutator.getType())
-              : destinationValue);
+              : destinationValue,
+              destPath);
     if (destinationValue == null)
       context.shadePath(propertyContext.destinationPath);
   }

--- a/core/src/main/java/org/modelmapper/internal/Mutator.java
+++ b/core/src/main/java/org/modelmapper/internal/Mutator.java
@@ -21,5 +21,5 @@ package org.modelmapper.internal;
  * @author Jonathan Halterman
  */
 interface Mutator extends InternalPropertyInfo {
-  void setValue(Object subject, Object value);
+  void setValue(Object subject, Object value, String destinationPath);
 }

--- a/core/src/main/java/org/modelmapper/internal/PropertyInfoImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/PropertyInfoImpl.java
@@ -74,11 +74,11 @@ abstract class PropertyInfoImpl<M extends Member> implements PropertyInfo {
       }
     }
 
-    public void setValue(Object subject, Object value) {
+    public void setValue(Object subject, Object value, String destinationPath) {
       try {
         member.set(subject, value);
       } catch (Exception e) {
-        throw new Errors().errorSettingValue(member, value, e).toMappingException();
+        throw new Errors().errorSettingValue(member, value, destinationPath, e).toMappingException();
       }
     }
 
@@ -121,11 +121,11 @@ abstract class PropertyInfoImpl<M extends Member> implements PropertyInfo {
       return member.getGenericParameterTypes()[0];
     }
 
-    public void setValue(Object subject, Object value) {
+    public void setValue(Object subject, Object value, String destinationPath) {
       try {
         member.invoke(subject, value);
       } catch (Exception e) {
-        throw new Errors().errorSettingValue(member, value, e).toMappingException();
+        throw new Errors().errorSettingValue(member, value, destinationPath, e).toMappingException();
       }
     }
 
@@ -214,7 +214,7 @@ abstract class PropertyInfoImpl<M extends Member> implements PropertyInfo {
     }
 
     @Override
-    public void setValue(Object subject, Object value) {
+    public void setValue(Object subject, Object value, String destinationPath) {
       valueWriterMember.setValue(subject, value);
     }
 

--- a/core/src/main/java/org/modelmapper/internal/TypeMapImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/TypeMapImpl.java
@@ -185,7 +185,7 @@ class TypeMapImpl<S, D> implements TypeMap<S, D> {
     try {
       result = engine.typeMap(context, this);
     } catch (Throwable t) {
-      context.errors.errorMapping(sourceType, destinationType, t);
+      context.errors.errorMapping(sourceType, destinationType, context.getDestinationPath(), t);
     }
 
     context.errors.throwMappingExceptionIfErrorsExist();
@@ -201,7 +201,7 @@ class TypeMapImpl<S, D> implements TypeMap<S, D> {
     try {
       engine.typeMap(context, this);
     } catch (Throwable t) {
-      context.errors.errorMapping(sourceType, destinationType, t);
+      context.errors.errorMapping(sourceType, destinationType, context.getDestinationPath(), t);
     }
 
     context.errors.throwMappingExceptionIfErrorsExist();

--- a/core/src/main/java/org/modelmapper/internal/converter/BooleanConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/BooleanConverter.java
@@ -45,7 +45,7 @@ class BooleanConverter implements ConditionalConverter<Object, Boolean> {
       if (FALSE_STRINGSS[i].equals(stringValue))
         return Boolean.FALSE;
 
-    throw new Errors().errorMapping(context.getSource(), context.getDestinationType())
+    throw new Errors().errorMapping(context.getSource(), context.getDestinationType(), context.getDestinationPath())
         .toMappingException();
   }
 

--- a/core/src/main/java/org/modelmapper/internal/converter/CalendarConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/CalendarConverter.java
@@ -71,7 +71,7 @@ class CalendarConverter implements ConditionalConverter<Object, Object> {
     Class<?> destinationType = context.getDestinationType();
     if (!Calendar.class.isAssignableFrom(destinationType)
         && !destinationType.equals(XMLGregorianCalendar.class))
-      throw new Errors().errorMapping(source, destinationType).toMappingException();
+      throw new Errors().errorMapping(source, destinationType, context.getDestinationPath()).toMappingException();
 
     GregorianCalendar calendar = new GregorianCalendar();
 

--- a/core/src/main/java/org/modelmapper/internal/converter/DateConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/DateConverter.java
@@ -55,17 +55,18 @@ class DateConverter implements ConditionalConverter<Object, Date> {
       return null;
 
     Class<?> destinationType = context.getDestinationType();
+    String destinationPath = context.getDestinationPath();
 
     if (source instanceof Date)
-      return dateFor(((Date) source).getTime(), destinationType);
+      return dateFor(((Date) source).getTime(), destinationType, destinationPath);
     if (source instanceof Calendar)
-      return dateFor(((Calendar) source).getTimeInMillis(), destinationType);
+      return dateFor(((Calendar) source).getTimeInMillis(), destinationType, destinationPath);
     if (source instanceof XMLGregorianCalendar)
       return dateFor(((XMLGregorianCalendar) source).toGregorianCalendar().getTimeInMillis(),
-          destinationType);
+          destinationType, destinationPath);
     if (source instanceof Long)
-      return dateFor(((Long) source).longValue(), destinationType);
-    return dateFor(source.toString(), context.getDestinationType());
+      return dateFor(((Long) source).longValue(), destinationType, destinationPath);
+    return dateFor(source.toString(), context.getDestinationType(), destinationPath);
   }
 
   public MatchResult match(Class<?> sourceType, Class<?> destinationType) {
@@ -76,7 +77,7 @@ class DateConverter implements ConditionalConverter<Object, Date> {
         : MatchResult.NONE;
   }
 
-  Date dateFor(long source, Class<?> destinationType) {
+  Date dateFor(long source, Class<?> destinationType, String destinationPath) {
     if (destinationType.equals(Date.class))
       return new Date(source);
     if (destinationType.equals(java.sql.Date.class))
@@ -86,13 +87,13 @@ class DateConverter implements ConditionalConverter<Object, Date> {
     if (destinationType.equals(Timestamp.class))
       return new Timestamp(source);
 
-    throw new Errors().errorMapping(source, destinationType).toMappingException();
+    throw new Errors().errorMapping(source, destinationType, destinationPath).toMappingException();
   }
 
-  Date dateFor(String source, Class<?> destinationType) {
+  Date dateFor(String source, Class<?> destinationType, String destinationPath) {
     String sourceString = toString().trim();
     if (sourceString.length() == 0)
-      throw new Errors().errorMapping(source, destinationType).toMappingException();
+      throw new Errors().errorMapping(source, destinationType, destinationPath).toMappingException();
 
     if (destinationType.equals(java.sql.Date.class)) {
       try {
@@ -124,6 +125,6 @@ class DateConverter implements ConditionalConverter<Object, Date> {
       }
     }
 
-    throw new Errors().errorMapping(source, destinationType).toMappingException();
+    throw new Errors().errorMapping(source, destinationType, destinationPath).toMappingException();
   }
 }

--- a/core/src/main/java/org/modelmapper/internal/converter/NumberConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/NumberConverter.java
@@ -61,18 +61,19 @@ class NumberConverter implements ConditionalConverter<Object, Number> {
       return null;
 
     Class<?> destinationType = Primitives.wrapperFor(context.getDestinationType());
+    String destinationPath = context.getDestinationPath();
 
     if (source instanceof Number)
-      return numberFor((Number) source, destinationType);
+      return numberFor((Number) source, destinationType, destinationPath);
     if (source instanceof Boolean)
-      return numberFor(((Boolean) source).booleanValue() ? 1 : 0, destinationType);
+      return numberFor(((Boolean) source).booleanValue() ? 1 : 0, destinationType, destinationPath);
     if (source instanceof Date && Long.class.equals(destinationType))
       return Long.valueOf(((Date) source).getTime());
     if (source instanceof Calendar && Long.class.equals(destinationType))
       return Long.valueOf(((Calendar) source).getTime().getTime());
     if (source instanceof XMLGregorianCalendar && Long.class.equals(destinationType))
       return ((XMLGregorianCalendar) source).toGregorianCalendar().getTimeInMillis();
-    return numberFor(source.toString(), destinationType);
+    return numberFor(source.toString(), destinationType, destinationPath);
   }
 
   public MatchResult match(Class<?> sourceType, Class<?> destinationType) {
@@ -90,7 +91,7 @@ class NumberConverter implements ConditionalConverter<Object, Number> {
   /**
    * Creates a Number for the {@code source} and {@code destinationType}.
    */
-  Number numberFor(Number source, Class<?> destinationType) {
+  Number numberFor(Number source, Class<?> destinationType, String destinationPath) {
     if (destinationType.equals(source.getClass()))
       return source;
 
@@ -149,13 +150,13 @@ class NumberConverter implements ConditionalConverter<Object, Number> {
         return BigInteger.valueOf(source.longValue());
     }
 
-    throw new Errors().errorMapping(source, destinationType).toMappingException();
+    throw new Errors().errorMapping(source, destinationType, destinationPath).toMappingException();
   }
 
   /**
    * Creates a Number for the {@code source} and {@code destinationType}.
    */
-  Number numberFor(String source, Class<?> destinationType) {
+  Number numberFor(String source, Class<?> destinationType, String destinationPath) {
     String sourceString = source.trim();
     if (sourceString.length() == 0)
       return null;
@@ -178,9 +179,9 @@ class NumberConverter implements ConditionalConverter<Object, Number> {
       if (destinationType.equals(BigInteger.class))
         return new BigInteger(source);
     } catch (Exception e) {
-      throw new Errors().errorMapping(source, destinationType, e).toMappingException();
+      throw new Errors().errorMapping(source, destinationType, destinationPath, e).toMappingException();
     }
 
-    throw new Errors().errorMapping(source, destinationType).toMappingException();
+    throw new Errors().errorMapping(source, destinationType, destinationPath).toMappingException();
   }
 }

--- a/core/src/main/java/org/modelmapper/spi/MappingContext.java
+++ b/core/src/main/java/org/modelmapper/spi/MappingContext.java
@@ -82,6 +82,11 @@ public interface MappingContext<S, D> {
   Type getGenericDestinationType();
 
   /**
+   * Returns the destination absolute path.
+   */
+  String getDestinationPath();
+
+  /**
    * Returns the mapping associated with the mapping request else {@code null} if the request did
    * not originate from a {@code TypeMap}.
    */

--- a/core/src/test/java/org/modelmapper/internal/MatchingStrategyTestSupport.java
+++ b/core/src/test/java/org/modelmapper/internal/MatchingStrategyTestSupport.java
@@ -167,7 +167,7 @@ public class MatchingStrategyTestSupport {
       return memberClass;
     }
 
-    public void setValue(Object subject, Object value) {
+    public void setValue(Object subject, Object value, String destinationPath) {
     }
 
     public Object getValue(Object subject) {


### PR DESCRIPTION
 Provide destinationPath in error messages for Mapping, Convert, Set, Instantiate.

Current error messages lack of debug information:
which property is failed to map.

For example:

```
org.modelmapper.MappingException: ModelMapper mapping errors:

1) Failed to instantiate instance of destination java.util.List. Ensure that java.util.List has a non-private no-argument constructor.

1 error

	at org.modelmapper.internal.Errors.throwMappingExceptionIfErrorsExist(Errors.java:380)
	at org.modelmapper.internal.MappingEngineImpl.map(MappingEngineImpl.java:80)
	at org.modelmapper.ModelMapper.mapInternal(ModelMapper.java:573)
	at org.modelmapper.ModelMapper.map(ModelMapper.java:406)
Caused by: java.lang.NoSuchMethodException: java.util.List.<init>()
	at java.lang.Class.getConstructor0(Class.java:3082)
	at java.lang.Class.getDeclaredConstructor(Class.java:2178)
	at org.modelmapper.internal.MappingEngineImpl.instantiate(MappingEngineImpl.java:332)
	at org.modelmapper.internal.MappingEngineImpl.createDestination(MappingEngineImpl.java:347)
	at org.modelmapper.internal.MappingEngineImpl.typeMap(MappingEngineImpl.java:140)
	at org.modelmapper.internal.MappingEngineImpl.map(MappingEngineImpl.java:114)
	at org.modelmapper.internal.MappingEngineImpl.setDestinationValue(MappingEngineImpl.java:241)
	at org.modelmapper.internal.MappingEngineImpl.propertyMap(MappingEngineImpl.java:187)
	at org.modelmapper.internal.MappingEngineImpl.typeMap(MappingEngineImpl.java:151)
	at org.modelmapper.internal.MappingEngineImpl.map(MappingEngineImpl.java:105)
	at org.modelmapper.internal.MappingEngineImpl.map(MappingEngineImpl.java:71)
	... 43 more

```