### PR TITLE
Add non-merging collection converter and configuration option to use one or the other

### DIFF
--- a/core/src/main/java/org/modelmapper/config/Configuration.java
+++ b/core/src/main/java/org/modelmapper/config/Configuration.java
@@ -15,19 +15,13 @@
  */
 package org.modelmapper.config;
 
-import java.util.List;
-
 import org.modelmapper.Condition;
 import org.modelmapper.PropertyMap;
 import org.modelmapper.Provider;
-import org.modelmapper.spi.ConditionalConverter;
+import org.modelmapper.spi.*;
 import org.modelmapper.spi.ConditionalConverter.MatchResult;
-import org.modelmapper.spi.MatchingStrategy;
-import org.modelmapper.spi.NameTokenizer;
-import org.modelmapper.spi.NameTransformer;
-import org.modelmapper.spi.NamingConvention;
-import org.modelmapper.spi.ValueReader;
-import org.modelmapper.spi.ValueWriter;
+
+import java.util.List;
 
 /**
  * Configures conventions used during the matching process.
@@ -259,6 +253,21 @@ public interface Configuration {
   boolean isDeepCopyEnabled();
 
   /**
+   * Returns whether collections should be 'merged' when mapped.
+   * When {@code true}, mapping a source collection of size {@code m}
+   * to a destination collection of size {@code n} with {@code m < n} results
+   * in a collection with the first {@code m} elements mapped from the source and elements from
+   * {@code m+1} to {@code n} being preserved from the destination collection.
+   * When {@code false} the elements of the destination collection are not preserved if they are not present
+   * in the source collection.
+   *
+   * @see #setCollectionsMergeEnabled(boolean)
+   * @see org.modelmapper.internal.converter.MergingCollectionConverter
+   * @see org.modelmapper.internal.converter.NonMergingCollectionConverter
+   */
+  boolean isCollectionsMergeEnabled();
+
+  /**
    * Sets whether destination properties that match more than one source property should be ignored.
    * When true, ambiguous destination properties are skipped during the matching process. When
    * false, a ConfigurationException is thrown when ambiguous properties are encountered.
@@ -352,6 +361,19 @@ public interface Configuration {
    * @see org.modelmapper.internal.converter.AssignableConverter
    */
   Configuration setDeepCopyEnabled(boolean enabled);
+
+  /**
+   * Sets whether the 'merging' of collections should be enabled. When {@code true} (default), ModelMapper will
+   * map the elements of the source collection to the destination collection and keep any elements of the destination collection
+   * when the source collection is smaller than the destination collection.
+   * When {@code false} the destination collection only consists of the elements of the source collection after mapping.
+   *
+   * @param enabled
+   * @see #isCollectionsMergeEnabled()
+   * @see org.modelmapper.internal.converter.MergingCollectionConverter
+   * @see org.modelmapper.internal.converter.NonMergingCollectionConverter
+   */
+  Configuration setCollectionsMergeEnabled(boolean enabled);
 
   /**
    * Sets whether to use an OSGi Class Loader Bridge as described in the following article:

--- a/core/src/main/java/org/modelmapper/internal/converter/ConverterStore.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/ConverterStore.java
@@ -15,21 +15,21 @@
  */
 package org.modelmapper.internal.converter;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.modelmapper.spi.ConditionalConverter;
 import org.modelmapper.spi.ConditionalConverter.MatchResult;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * @author Jonathan Halterman
  */
 public final class ConverterStore {
   private static final ConditionalConverter<?, ?>[] DEFAULT_CONVERTERS = new ConditionalConverter<?, ?>[] {
-      new ArrayConverter(), new CollectionConverter(), new MapConverter(),
-      new AssignableConverter(), new StringConverter(), new EnumConverter(), new NumberConverter(),
-      new BooleanConverter(), new CharacterConverter(), new DateConverter(),
-      new CalendarConverter() };
+          new ArrayConverter(), new MergingCollectionConverter(), new MapConverter(),
+          new AssignableConverter(), new StringConverter(), new EnumConverter(), new NumberConverter(),
+          new BooleanConverter(), new CharacterConverter(), new DateConverter(),
+          new CalendarConverter() };
 
   private final List<ConditionalConverter<?, ?>> converters;
 

--- a/core/src/main/java/org/modelmapper/internal/converter/MergingCollectionConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/MergingCollectionConverter.java
@@ -15,19 +15,20 @@
  */
 package org.modelmapper.internal.converter;
 
-import java.util.Collection;
-import java.util.Iterator;
 import org.modelmapper.internal.util.Iterables;
 import org.modelmapper.internal.util.MappingContextHelper;
 import org.modelmapper.spi.ConditionalConverter;
 import org.modelmapper.spi.MappingContext;
 
+import java.util.Collection;
+import java.util.Iterator;
+
 /**
  * Converts {@link Collection} and array instances to {@link Collection} instances.
- * 
+ *
  * @author Jonathan Halterman
  */
-class CollectionConverter implements ConditionalConverter<Object, Collection<Object>> {
+public class MergingCollectionConverter implements ConditionalConverter<Object, Collection<Object>> {
   @Override
   public MatchResult match(Class<?> sourceType, Class<?> destinationType) {
     return Iterables.isIterable(sourceType) && Collection.class.isAssignableFrom(destinationType) ? MatchResult.FULL

--- a/core/src/main/java/org/modelmapper/internal/converter/NonMergingCollectionConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/NonMergingCollectionConverter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelmapper.internal.converter;
+
+import org.modelmapper.internal.util.Iterables;
+import org.modelmapper.internal.util.MappingContextHelper;
+import org.modelmapper.spi.ConditionalConverter;
+import org.modelmapper.spi.MappingContext;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * Converts {@link Collection} and array instances to {@link Collection} instances.
+ *
+ * @author Jonathan Halterman
+ */
+public class NonMergingCollectionConverter implements ConditionalConverter<Object, Collection<Object>> {
+  @Override
+  public MatchResult match(Class<?> sourceType, Class<?> destinationType) {
+    return Iterables.isIterable(sourceType) && Collection.class.isAssignableFrom(destinationType) ? MatchResult.FULL
+        : MatchResult.NONE;
+  }
+
+  @Override
+  public Collection<Object> convert(MappingContext<Object, Collection<Object>> context) {
+    Object source = context.getSource();
+    if (source == null)
+      return null;
+
+    Collection<Object> originalDestination = context.getDestination();
+    Collection<Object> destination = MappingContextHelper.createCollection(context);
+    Class<?> elementType = MappingContextHelper.resolveDestinationGenericType(context);
+
+    int index = 0;
+    for (Iterator<Object> iterator = Iterables.iterator(source); iterator.hasNext(); index++) {
+      Object sourceElement = iterator.next();
+      Object element = null;
+      if (originalDestination != null)
+        element = Iterables.getElement(originalDestination, index);
+      if (sourceElement != null) {
+        MappingContext<?, ?> elementContext = element == null
+            ? context.create(sourceElement, elementType)
+            : context.create(sourceElement, element);
+        element = context.getMappingEngine().map(elementContext);
+      }
+      destination.add(element);
+    }
+
+    return destination;
+  }
+}

--- a/core/src/test/java/org/modelmapper/internal/converter/MergingCollectionConverterTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/MergingCollectionConverterTest.java
@@ -1,30 +1,19 @@
 package org.modelmapper.internal.converter;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-
-import org.modelmapper.Asserts;
 import org.modelmapper.spi.ConditionalConverter.MatchResult;
 import org.testng.annotations.Test;
+
+import java.util.*;
+
+import static org.testng.Assert.*;
 
 /**
  * @author Jonathan Halterman
  */
 @Test
-public class CollectionConverterTest extends AbstractConverterTest {
-  public CollectionConverterTest() {
-    super(new CollectionConverter());
+public class MergingCollectionConverterTest extends AbstractConverterTest {
+  public MergingCollectionConverterTest() {
+    super(new MergingCollectionConverter());
   }
 
   static class S {

--- a/core/src/test/java/org/modelmapper/internal/converter/NonMergingCollectionConverterTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/NonMergingCollectionConverterTest.java
@@ -1,0 +1,164 @@
+package org.modelmapper.internal.converter;
+
+import org.modelmapper.spi.ConditionalConverter.MatchResult;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+import static org.testng.Assert.*;
+
+/**
+ * @author Jonathan Halterman
+ */
+@Test
+public class NonMergingCollectionConverterTest extends AbstractConverterTest {
+  public NonMergingCollectionConverterTest() {
+    super(new NonMergingCollectionConverter());
+  }
+
+  static class S {
+ //   List<Integer> a = Arrays.asList(1, 2, 3);
+ //   int[] b = new int[] { 4, 5, 6 };
+    @SuppressWarnings({ "rawtypes", "unused" })
+    List rawlist = Arrays.asList(7, 8, 9);
+  }
+
+  static class D {
+ //   List<String> a;
+ //   Collection<String> b;
+    @SuppressWarnings("rawtypes")
+    List rawlist;
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertElementsFromArray() {
+    int[] source = new int[] { 1, 2, 3 };
+    List<Object> dest = modelMapper.map(source, List.class);
+    assertEquals(dest, Arrays.asList(1, 2, 3));
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertElementsFromList() {
+    List<Integer> list = Arrays.asList(1, 2, 3);
+    List<Object> dest = modelMapper.map(list, List.class);
+    assertEquals(dest, list);
+  }
+
+  public void shouldConvertElementsFromModel() {
+    D d = modelMapper.map(new S(), D.class);
+  //  assertEquals(d.a, Arrays.asList("1", "2", "3"));
+   // assertEquals(d.b, Arrays.asList("4", "5", "6"));
+    assertEquals(d.rawlist, Arrays.asList(7, 8, 9));
+  }
+
+  public void shouldConvertListToList() {
+    List<String> source = Arrays.asList("a", "b", "c");
+    assertEquals(convert(source, ArrayList.class), source);
+  }
+
+  public void shouldConvertArrayToList() {
+    String[] source = new String[] { "a", "b", "c" };
+    assertEquals(convert(source, ArrayList.class), Arrays.asList(source));
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertPrimitiveArrayToCollection() {
+    int[] source = new int[] { 1, 2, 3 };
+    Collection<Integer> dest = (Collection<Integer>) convert(source, Collection.class);
+    assertEquals(dest, Arrays.asList(1, 2, 3));
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertListToSet() {
+    List<String> source = Arrays.asList("a", "b", "c");
+    Set<String> dest = (Set<String>) convert(source, Set.class);
+    assertNotNull(dest);
+    assertEquals(dest.size(), 3);
+    assertTrue(dest.containsAll(source));
+  }
+
+  public void shouldConvertArrayToCollection() {
+    Collection<String> source = Arrays.asList("a", "b", "c");
+    assertEquals(convert(source, Collection.class), source);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertListToHashSet() {
+    List<String> source = Arrays.asList("a", "b", "c");
+    Set<String> dest = (Set<String>) convert(source, Set.class);
+    assertTrue(dest instanceof HashSet);
+    assertEquals(dest.size(), 3);
+    assertTrue(dest.containsAll(source));
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertListToSortedSet() {
+    List<String> source = Arrays.asList("a", "b", "c");
+    SortedSet<String> dest = (SortedSet<String>) convert(source, SortedSet.class);
+    assertNotNull(dest);
+    assertEquals(source, dest);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertListToListOverwrite() {
+    List<String> source = Arrays.asList("a", "b", "c");
+    List<String> destination = Arrays.asList("d", "e", "f");
+    Class<?> destinationType = List.class;
+    assertEquals(convert(source, destination, (Class<Object>) destinationType), source);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertListToListOverwriteExistNotMerge() {
+    List<String> source = Arrays.asList("a", "b", "c");
+    List<String> destination = Arrays.asList("d", "e", "f", "g");
+    Class<?> destinationType = List.class;
+    assertEquals(convert(source, destination, destinationType),
+        Arrays.asList("a", "b", "c"));
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertListToListOverwriteExpand() {
+    List<String> source = Arrays.asList("a", "b", "c");
+    List<String> destination = Arrays.asList("d", "e");
+    Class<?> destinationType = List.class;
+    assertEquals(convert(source, destination, destinationType),
+        Arrays.asList("a", "b", "c"));
+  }
+
+  static class SrcSortedSet {
+    SortedSet<Integer> genericSet = new TreeSet<Integer>(Arrays.asList(3, 1, 2));
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    SortedSet rawset = new TreeSet(Arrays.asList(9, 7, 8));
+  }
+
+  static class DestSortedSet {
+    SortedSet<Integer> genericSet;
+    @SuppressWarnings("rawtypes")
+    SortedSet rawset;
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertElementsFromSortedSet() {
+    SortedSet<Integer> s = new TreeSet<Integer>(Arrays.asList(3, 1, 2));
+    SortedSet<Object> d = modelMapper.map(s, SortedSet.class);
+    assertEquals(d, s);
+    assertTrue(d instanceof SortedSet);
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public void shouldConvertElementsFromSortedSetModel() {
+    DestSortedSet d = modelMapper.map(new SrcSortedSet(), DestSortedSet.class);
+    assertEquals(d.genericSet, new TreeSet<Integer>(Arrays.asList(1, 2, 3)));
+    assertEquals(d.rawset, new TreeSet(Arrays.asList(7, 8, 9)));
+    assertTrue(d.genericSet instanceof SortedSet);
+    assertTrue(d.rawset instanceof SortedSet);
+  }
+
+  public void testMatches() {
+    assertEquals(converter.match(ArrayList.class, List.class), MatchResult.FULL);
+    assertEquals(converter.match(Object[].class, Set.class), MatchResult.FULL);
+
+    // Negative
+    assertEquals(converter.match(Map.class, ArrayList.class), MatchResult.NONE);
+  }
+}


### PR DESCRIPTION
ModelMapper may be used for DTO <-> Entity mapping in web service applications and is even suggested to be used for that by tutorials (i.e. https://www.baeldung.com/entity-to-and-from-dto-for-a-java-spring-application).

The current behavior of the `CollectionConverter` is not expected in such a use-case as it preserves the elements in the destination collection when the source collection is smaller, refer to #423 and #386.

This pull request 
- adds a new converter, the `NonMergingCollectionConverter`,
- renames the existing `CollectionConverter` to `MergingCollectionConverter`, 
- adds a configuration option to the `Configuration` interface,
- sets the current `CollectionConverter`, now the `MergingCollectionConverter` as default and 
- adjusts the `InheritingConfiguration` accordingly.