### PR TITLE
Change collections merge strategy breaks collection mapping

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/InheritingConfiguration.java
+++ b/core/src/main/java/org/modelmapper/internal/InheritingConfiguration.java
@@ -395,16 +395,10 @@ public class InheritingConfiguration implements Configuration {
 
   @Override
   public Configuration setCollectionsMergeEnabled(boolean enabled) {
-    if (enabled && !converterStore.hasConverter(MergingCollectionConverter.class)) {
-      if (converterStore.hasConverter(NonMergingCollectionConverter.class)) {
-        converterStore.removeConverter(NonMergingCollectionConverter.class);
-      }
-      converterStore.addConverter(new MergingCollectionConverter());
-    } else if (!enabled && !converterStore.hasConverter(NonMergingCollectionConverter.class)) {
-        if (converterStore.hasConverter(MergingCollectionConverter.class)){
-            converterStore.removeConverter(MergingCollectionConverter.class);
-        }
-        converterStore.addConverter(new NonMergingCollectionConverter());
+    if (enabled) {
+      converterStore.replaceConverter(NonMergingCollectionConverter.class, new MergingCollectionConverter());
+    } else {
+      converterStore.replaceConverter(MergingCollectionConverter.class, new NonMergingCollectionConverter());
     }
     return this;
   }

--- a/core/src/main/java/org/modelmapper/internal/converter/ConverterStore.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/ConverterStore.java
@@ -83,6 +83,29 @@ public final class ConverterStore {
     return this;
   }
 
+  /**
+   * Replaces the converter of specified class with the given instance.
+   * <p>
+   * If the converter to replace is not found than no replace is performed,
+   * the converters are left untouched.
+   *
+   * @param converterClass to replace
+   * @param converter instance with which to replace it
+   * @return converter store itself
+   */
+  public ConverterStore replaceConverter(Class<? extends ConditionalConverter<?, ?>> converterClass, ConditionalConverter<?, ?> converter) {
+      ConditionalConverter<?, ?> matchConverter = getConverterByType(converterClass);
+      if (matchConverter != null) {
+        int idx = converters.indexOf(matchConverter);
+        if (idx != -1) {
+          // because of concurrency do not use List#set(int, T obj) to avoid to replace a wrong converter
+          converters.remove(matchConverter);
+          converters.add(idx, converter);
+        }
+      }
+      return this;
+  }
+
   private ConditionalConverter<?, ?> getConverterByType(Class<? extends ConditionalConverter<?, ?>> converterClass) {
     for (ConditionalConverter<?, ?> converter : converters) {
       if (converter.getClass().equals(converterClass))
@@ -90,4 +113,5 @@ public final class ConverterStore {
     }
     return null;
   }
+
 }

--- a/core/src/test/java/org/modelmapper/functional/config/DeepCopyEnabledTest.java
+++ b/core/src/test/java/org/modelmapper/functional/config/DeepCopyEnabledTest.java
@@ -35,6 +35,8 @@ public class DeepCopyEnabledTest extends AbstractTest {
 
   public void shouldDeepCopy() {
     modelMapper.getConfiguration().setDeepCopyEnabled(true);
+    modelMapper.getConfiguration().setDeepCopyEnabled(false);
+    modelMapper.getConfiguration().setDeepCopyEnabled(true);
 
     Source source = new Source(new Property("text"));
     Destination destination = modelMapper.map(source, Destination.class);
@@ -51,6 +53,8 @@ public class DeepCopyEnabledTest extends AbstractTest {
   }
 
   public void shouldNotDeepCopy() {
+    modelMapper.getConfiguration().setDeepCopyEnabled(false);
+    modelMapper.getConfiguration().setDeepCopyEnabled(true);
     modelMapper.getConfiguration().setDeepCopyEnabled(false);
 
     Source source = new Source(new Property("text"));

--- a/core/src/test/java/org/modelmapper/internal/converter/MergingCollectionConverterTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/MergingCollectionConverterTest.java
@@ -161,4 +161,13 @@ public class MergingCollectionConverterTest extends AbstractConverterTest {
     // Negative
     assertEquals(converter.match(Map.class, ArrayList.class), MatchResult.NONE);
   }
+
+  public void testMergeBehaviourSetToFalseAndThanToTrue() {
+    modelMapper.getConfiguration().setCollectionsMergeEnabled(true); // default in 2.3.3
+    modelMapper.getConfiguration().setCollectionsMergeEnabled(false);
+    modelMapper.getConfiguration().setCollectionsMergeEnabled(true); // back to default
+
+    List<D> result = modelMapper.map(Arrays.asList(new S()), new org.modelmapper.TypeToken<List<D>>() {}.getType());
+    assertTrue(result.get(0) instanceof D);
+  }
 }

--- a/core/src/test/java/org/modelmapper/internal/converter/MergingCollectionConverterTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/MergingCollectionConverterTest.java
@@ -167,7 +167,8 @@ public class MergingCollectionConverterTest extends AbstractConverterTest {
     modelMapper.getConfiguration().setCollectionsMergeEnabled(false);
     modelMapper.getConfiguration().setCollectionsMergeEnabled(true); // back to default
 
-    List<D> result = modelMapper.map(Arrays.asList(new S()), new org.modelmapper.TypeToken<List<D>>() {}.getType());
+    List<S> source = Arrays.asList(new S());
+    List<D> result = modelMapper.map(source, new org.modelmapper.TypeToken<List<D>>() {}.getType());
     assertTrue(result.get(0) instanceof D);
   }
 }


### PR DESCRIPTION
This PR demostrate with a test case that if I change the default configuration of merge collection strategy I'm not able to map a `Collection<S>` into `Collection<D>` anymore. The result will be always a `Collection<S>`.

`modelMapper.map(listOfS, new org.modelmapper.TypeToken<List <D>>() {}.getType())` return listOfS instance.

The issue happens because when the configuration is changed the MergingCollectionConverter is moved from position 1 in the list of converters in the converterStore as the latest conveter. Maybe some other converter takes over and the `MergingCollectionConverter.convert(MappingContext<Object, Collection<Object>> context)` is never called.

To solve the issue the MergingCollectionConverter should be added again the same position as before. Or change the conveters list into weighted list. So that when add a conveter you can specify also a priority.

@chhsiao90 what do you think? Do you prefer a ConverterStore.converters as weighted list or simply add a method `addConverter` that takes also an index?