### PR TITLE
Hibernate proxies are now detected when implicit mapping is set to f…

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
@@ -263,7 +263,7 @@ public class MappingEngineImpl implements MappingEngine {
       Object source, MappingImpl mapping) {
     Class<?> sourceType = mapping.getSourceType();
     if (source != null)
-      sourceType = source.getClass();
+      sourceType = Types.deProxy(source.getClass());
     boolean cyclic = mapping instanceof PropertyMapping && ((PropertyMappingImpl) mapping).cyclic;
     Class<Object> destinationType = (Class<Object>) mapping.getLastDestinationProperty().getType();
     Type genericDestinationType = context.genericDestinationPropertyType(mapping.getLastDestinationProperty().getGenericType());


### PR DESCRIPTION
When object A has an object B as a field and that object B is a hibernate proxy even if you have a typeMap defined model-mapper does not detect it properly. This only happens with implicitMapping set to false.

This change will fix that as it will de proxy the passed in instance.