### PR TITLE
allow mapping of generic map types

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/converter/MapConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/MapConverter.java
@@ -15,6 +15,8 @@
  */
 package org.modelmapper.internal.converter;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
@@ -23,6 +25,8 @@ import java.util.Map.Entry;
 
 import net.jodah.typetools.TypeResolver;
 import net.jodah.typetools.TypeResolver.Unknown;
+
+import org.modelmapper.internal.util.Types;
 import org.modelmapper.spi.ConditionalConverter;
 import org.modelmapper.spi.Mapping;
 import org.modelmapper.spi.MappingContext;
@@ -31,7 +35,7 @@ import org.modelmapper.spi.PropertyMapping;
 
 /**
  * Converts {@link Map} instances to each other.
- * 
+ *
  * @author Jonathan Halterman
  */
 class MapConverter implements ConditionalConverter<Map<?, ?>, Map<Object, Object>> {
@@ -54,6 +58,10 @@ class MapConverter implements ConditionalConverter<Map<?, ?>, Map<Object, Object
         keyElementType = elementTypes[0] == Unknown.class ? Object.class : elementTypes[0];
         valueElementType = elementTypes[1] == Unknown.class ? Object.class : elementTypes[1];
       }
+    } else if (context.getGenericDestinationType() instanceof ParameterizedType) {
+      Type[] elementTypes = ((ParameterizedType) context.getGenericDestinationType()).getActualTypeArguments();
+      keyElementType = Types.rawTypeFor(elementTypes[0]);
+      valueElementType = Types.rawTypeFor(elementTypes[1]);
     }
 
     for (Entry<?, ?> entry : source.entrySet()) {

--- a/core/src/test/java/org/modelmapper/internal/converter/MapConverterTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/MapConverterTest.java
@@ -1,14 +1,19 @@
 package org.modelmapper.internal.converter;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.modelmapper.ModelMapper;
 import org.modelmapper.spi.ConditionalConverter.MatchResult;
 import org.testng.annotations.Test;
 
@@ -138,6 +143,20 @@ public class MapConverterTest extends AbstractConverterTest {
     assertTrue(d.a instanceof SortedMap);
     assertTrue(d.b instanceof SortedMap);
     assertTrue(d.rawmap instanceof SortedMap);
+  }
+
+  public void shouldConvertWithGenericTypes() {
+    Map<Integer, BigDecimal> numbers = Collections.singletonMap(1, BigDecimal.valueOf(2));
+
+    Type mapType = new org.modelmapper.TypeToken<Map<Long, String>>() {}.getType();
+    Map<Long, String> mixed =  new ModelMapper().map(numbers, mapType);
+
+    assertFalse(mixed.isEmpty());
+    assertTrue(mixed.size() == 1);
+    assertTrue(mixed.keySet().iterator().next() instanceof Long);
+    assertTrue(mixed.keySet().iterator().next() == 1l);
+    assertTrue(mixed.values().iterator().next() instanceof String);
+    assertTrue(mixed.values().iterator().next().equals("2"));
   }
 
   public void testMatches() {


### PR DESCRIPTION
Allow mapping of generic map types with TypeToken:
```
Map<Integer, BigDecimal> numbers = Collections.singletonMap(1, BigDecimal.valueOf(2));
Type mapType = new org.modelmapper.TypeToken<Map<Long, String>>() {}.getType();
Map<Long, String> mixed =  new ModelMapper().map(numbers, mapType);
```