### PR TITLE
Upgrade ASM from 7.0 to 7.1, in order to support Java 13.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <cglib.version>3.2.9</cglib.version>
-    <asm.version>7.0</asm.version>
+    <asm.version>7.1</asm.version>
     <objenesis.version>2.6</objenesis.version>
     <typetools.version>0.5.0</typetools.version>
     <bytebuddy.version>1.9.4</bytebuddy.version>


### PR DESCRIPTION
Based on release notes of ASM here, https://asm.ow2.io/versions.html

```
3 March 2019: ASM 7.1 (tag ASM_7_1)
new constant Opcodes.V13 for Java 13
small optimizations in asm.Type
check signatures in CheckMethodAdapter.visitLocalVariable
refactor unit tests to use Arrange-Act-Assert pattern
deprecations
deprecate ClassReader.b
deprecate ASMifiable and Textifiable (replaced with ASMifierSupport and TextifierSupport)
move deprecated Remapping*Adapter classes to new asm-deprecated.jar
delete asm.util.Printer buf and appendString (were previously deprecated)
bug fixes
317863: Remapper logic for InnerClasses attribute is wrong for method-local Java classes
317866: Expanded frames result in incorrect types for primitive arrays of more than seven dimensions
317868: IllegalArgumentException at Frame.getAbstractTypeFromDescriptor on class name with parentheses
317869: CheckClassAdapter requires non-null ClassVisitor that returns non-null MethodVisitor
```

We need to upgrade this dependency to 7.1, in order to support Java-13. 

Ping @chhsiao90, thanks. 
