### PR TITLE
Update ASM to 7.2 to be JDK 13 compatible.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,27 +13,11 @@
 
   <properties>
     <cglib.version>3.2.9</cglib.version>
-    <asm.version>7.0</asm.version>
     <objenesis.version>2.6</objenesis.version>
     <typetools.version>0.5.0</typetools.version>
     <bytebuddy.version>1.9.4</bytebuddy.version>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm</artifactId>
-        <version>${asm.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm-commons</artifactId>
-        <version>${asm.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
+  
   <dependencies>
     <dependency>
       <groupId>org.ow2.asm</groupId>
@@ -146,6 +130,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
         <configuration>
           <suiteXmlFiles>
             <suiteXmlFile>src/test/resources/testngAll.xml</suiteXmlFile>
@@ -197,6 +182,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.2</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,25 @@
     <module>examples</module>
   </modules>
 
+  <properties>
+    <asm.version>7.2</asm.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>${asm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-commons</artifactId>
+        <version>${asm.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.testng</groupId>
@@ -75,9 +94,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
ASM must be updated to be JDK 13 compatible.

Moved the DependencyManagement block of ASM to the parent, as multiple sub-modules uses ASM. Otherwise, the sub-modules would use a different version of ASM (7.0 through transitive dependency of ByteBuddy).