### PR TITLE
Try to fix IllegalArgumentException due to package renaming

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/ProxyFactory.java
+++ b/core/src/main/java/org/modelmapper/internal/ProxyFactory.java
@@ -89,7 +89,7 @@ class ProxyFactory {
 
     try {
       final DynamicType.Unloaded<T> unloaded = new ByteBuddy()
-		      .with(new NamingStrategy.SuffixingRandom("ByteBuddy", NO_PREFIX))
+          .with(new NamingStrategy.SuffixingRandom("ByteBuddy", NO_PREFIX))
           .subclass(type)
           .method(METHOD_FILTER)
           .intercept(InvocationHandlerAdapter.of(interceptor))

--- a/core/src/main/java/org/modelmapper/internal/ProxyFactory.java
+++ b/core/src/main/java/org/modelmapper/internal/ProxyFactory.java
@@ -15,6 +15,7 @@
  */
 package org.modelmapper.internal;
 
+import static net.bytebuddy.NamingStrategy.SuffixingRandom.NO_PREFIX;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
@@ -23,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.NamingStrategy;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassInjector;
@@ -87,6 +89,7 @@ class ProxyFactory {
 
     try {
       final DynamicType.Unloaded<T> unloaded = new ByteBuddy()
+		      .with(new NamingStrategy.SuffixingRandom("ByteBuddy", NO_PREFIX))
           .subclass(type)
           .method(METHOD_FILTER)
           .intercept(InvocationHandlerAdapter.of(interceptor))


### PR DESCRIPTION
This is regarding issue #482.

After debugging I think I've found that the problem seems to arise due to the renaming of the "net.bytebuddy" package to "org.modelmapper.internal.bytebuddy" when using the maven-shade-plugin on modelmapper's core pom.xml (line 128).

This also renames the `BYTE_BUDDY_RENAME_PACKAGE` constant on `net.bytebuddy.NamingStrategy.SuffixingRandom` that is used on the `ByteBuddy` constructor to be used as `namingStrategy` from **net.bytebuddy.renamed** to **org.modelmapper.internal.bytebuddy.renamed**.

This makes that on proxy generation on `org.modelmapper.internal.ProxyFactory#proxyFor(java.lang.Class<T>, java.lang.reflect.InvocationHandler, org.modelmapper.internal.Errors, boolean)` the exception mentioned on the issue to be thrown.

The way I've tried to fix it was simply using an empty string as prefix, which seems to solve the problem and give no additional problems (modelmapper's and my own tests are passing after the fix).

Maybe the error is on ByteBuddy's side and the normal renaming doesn't work too, but I wasn't able to try it.

Glad to answer any questions ;)