### PR TITLE
Update typetools to 0.6.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
     <cglib.version>3.2.9</cglib.version>
     <asm.version>7.2</asm.version>
     <objenesis.version>2.6</objenesis.version>
-    <typetools.version>0.5.0</typetools.version>
+    <typetools.version>0.6.2</typetools.version>
     <bytebuddy.version>1.9.4</bytebuddy.version>
   </properties>
 


### PR DESCRIPTION
Update typetools to version 0.6.2 to better support jdk11