### PR TITLE
Correção na resolução de tipo de acessor de campo.

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/PropertyInfoSetResolver.java
+++ b/core/src/main/java/org/modelmapper/internal/PropertyInfoSetResolver.java
@@ -33,149 +33,151 @@ import org.modelmapper.spi.ValueWriter;
 
 /**
  * Resolves sets of PropertyInfo for a type's accessors or mutators.
- * 
+ *
  * @author Jonathan Halterman
  */
 final class PropertyInfoSetResolver {
-  private PropertyInfoSetResolver() {
-  }
-
-  private static class ResolveRequest<M extends AccessibleObject & Member, PI extends PropertyInfo> {
-    PropertyInfoResolver<M, PI> propertyResolver;
-    PropertyType propertyType;
-    Configuration config;
-    AccessLevel accessLevel;
-    NamingConvention namingConvention;
-    NameTransformer nameTransformer;
-  }
-
-  static boolean canAccessMember(Member member, AccessLevel accessLevel) {
-    int mod = member.getModifiers();
-    switch (accessLevel) {
-      default:
-      case PUBLIC:
-        return Modifier.isPublic(mod);
-      case PROTECTED:
-        return Modifier.isPublic(mod) || Modifier.isProtected(mod);
-      case PACKAGE_PRIVATE:
-        return Modifier.isPublic(mod) || Modifier.isProtected(mod) || !Modifier.isPrivate(mod);
-      case PRIVATE:
-        return true;
-    }
-  }
-
-  static <T> Map<String, Accessor> resolveAccessors(T source, Class<T> type,
-      InheritingConfiguration configuration) {
-    ValueReader<T> valueReader = configuration.valueAccessStore.getFirstSupportedReader(type);
-    if (source != null && valueReader != null)
-      return resolveAccessorsFromValueReader(source, configuration, valueReader);
-    else
-      return resolveProperties(type, true, configuration);
-  }
-
-  static <T> Map<String, Accessor> resolveAccessorsFromValueReader(T source,
-      InheritingConfiguration configuration, ValueReader<T> valueReader) {
-    Map<String, Accessor> accessors = new LinkedHashMap<String, Accessor>();
-    NameTransformer nameTransformer = configuration.getSourceNameTransformer();
-    for (String memberName : valueReader.memberNames(source)) {
-      ValueReader.Member<?> member = valueReader.getMember(source, memberName);
-      if (member != null)
-        accessors.put(nameTransformer.transform(memberName, NameableType.GENERIC),
-            PropertyInfoImpl.ValueReaderPropertyInfo.fromMember(member, memberName));
-    }
-    return accessors;
-  }
-
-  static <T> Map<String, Mutator> resolveMutators(Class<T> type, InheritingConfiguration configuration) {
-    ValueWriter<T> valueWriter = configuration.valueMutateStore.getFirstSupportedWriter(type);
-    if (valueWriter != null && valueWriter.isResolveMembersSupport())
-      return resolveMutatorsFromValueWriter(type, configuration, valueWriter);
-    return resolveProperties(type, false, configuration);
-  }
-  static <T> Map<String, Mutator> resolveMutatorsFromValueWriter(Class<T> type,
-      InheritingConfiguration configuration, ValueWriter<T> valueWriter) {
-    Map<String, Mutator> mutators = new LinkedHashMap<String, Mutator>();
-    NameTransformer nameTransformer = configuration.getSourceNameTransformer();
-    for (String memberName : valueWriter.memberNames(type)) {
-      ValueWriter.Member<?> member = valueWriter.getMember(type, memberName);
-      if (member != null)
-        mutators.put(nameTransformer.transform(memberName, NameableType.GENERIC),
-            PropertyInfoImpl.ValueWriterPropertyInfo.fromMember(member, memberName));
-    }
-    return mutators;
-  }
-
-  @SuppressWarnings({ "unchecked" })
-  private static <M extends AccessibleObject & Member, PI extends PropertyInfo> Map<String, PI> resolveProperties(
-      Class<?> type, boolean access, Configuration configuration) {
-    Map<String, PI> properties = new LinkedHashMap<String, PI>();
-    if (configuration.isFieldMatchingEnabled()) {
-      properties.putAll(resolveProperties(type, type, PropertyInfoSetResolver.<M, PI>resolveRequest(configuration, access, true)));
-    }
-    properties.putAll(resolveProperties(type, type, PropertyInfoSetResolver.<M, PI>resolveRequest(configuration, access, false)));
-    return properties;
-  }
-
-  /**
-   * Populates the {@code resolveRequest.propertyInfo} with {@code resolveRequest.propertyResolver}
-   * resolved property info for properties that are accessible by the
-   * {@code resolveRequest.accessLevel} and satisfy the {@code resolveRequest.namingConvention}.
-   * Uses a depth-first search so that child properties of the same name override parents.
-   */
-  private static <M extends AccessibleObject & Member, PI extends PropertyInfo> Map<String, PI> resolveProperties(
-      Class<?> initialType, Class<?> type, ResolveRequest<M, PI> resolveRequest) {
-    Map<String, PI> properties = new LinkedHashMap<String, PI>();
-    Class<?> superType = type.getSuperclass();
-    if (superType != null && superType != Object.class && superType != Enum.class)
-      properties.putAll(resolveProperties(initialType, superType, resolveRequest));
-
-    for (M member : resolveRequest.propertyResolver.membersFor(type)) {
-      if (canAccessMember(member, resolveRequest.accessLevel)
-          && resolveRequest.propertyResolver.isValid(member)
-          && resolveRequest.namingConvention.applies(member.getName(), resolveRequest.propertyType)) {
-        String name = resolveRequest.nameTransformer.transform(member.getName(),
-            PropertyType.FIELD.equals(resolveRequest.propertyType) ? NameableType.FIELD
-                : NameableType.METHOD);
-        PI info = resolveRequest.propertyResolver.propertyInfoFor(initialType, member,
-            resolveRequest.config, name);
-        properties.put(name, info);
-
-        if (!Modifier.isPublic(member.getModifiers())
-            || !Modifier.isPublic(member.getDeclaringClass().getModifiers()))
-          try {
-            member.setAccessible(true);
-          } catch (SecurityException e) {
-            throw new AssertionError(e);
-          }
-      }
+    private PropertyInfoSetResolver() {
     }
 
-    return properties;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <M extends AccessibleObject & Member, PI extends PropertyInfo> ResolveRequest<M, PI> resolveRequest(
-      Configuration configuration, boolean access, boolean field) {
-    ResolveRequest<M, PI> resolveRequest = new ResolveRequest<M, PI>();
-    resolveRequest.config = configuration;
-    if (access) {
-      resolveRequest.namingConvention = configuration.getSourceNamingConvention();
-      resolveRequest.nameTransformer = configuration.getSourceNameTransformer();
-    } else {
-      resolveRequest.namingConvention = configuration.getDestinationNamingConvention();
-      resolveRequest.nameTransformer = configuration.getDestinationNameTransformer();
+    private static class ResolveRequest<M extends AccessibleObject & Member, PI extends PropertyInfo> {
+        PropertyInfoResolver<M, PI> propertyResolver;
+        PropertyType propertyType;
+        Configuration config;
+        AccessLevel accessLevel;
+        NamingConvention namingConvention;
+        NameTransformer nameTransformer;
     }
 
-    if (field) {
-      resolveRequest.propertyType = PropertyType.FIELD;
-      resolveRequest.accessLevel = configuration.getFieldAccessLevel();
-      resolveRequest.propertyResolver = (PropertyInfoResolver<M, PI>) PropertyInfoResolver.FIELDS;
-    } else {
-      resolveRequest.propertyType = PropertyType.METHOD;
-      resolveRequest.accessLevel = configuration.getMethodAccessLevel();
-      resolveRequest.propertyResolver = (PropertyInfoResolver<M, PI>) (access ? PropertyInfoResolver.ACCESSORS
-          : PropertyInfoResolver.MUTATORS);
+    static boolean canAccessMember(Member member, AccessLevel accessLevel) {
+        int mod = member.getModifiers();
+        switch (accessLevel) {
+            default:
+            case PUBLIC:
+                return Modifier.isPublic(mod);
+            case PROTECTED:
+                return Modifier.isPublic(mod) || Modifier.isProtected(mod);
+            case PACKAGE_PRIVATE:
+                return Modifier.isPublic(mod) || Modifier.isProtected(mod) || !Modifier.isPrivate(mod);
+            case PRIVATE:
+                return true;
+        }
     }
-    return resolveRequest;
-  }
+
+    static <T> Map<String, Accessor> resolveAccessors(T source, Class<T> type,
+                                                      InheritingConfiguration configuration) {
+        ValueReader<T> valueReader = configuration.valueAccessStore.getFirstSupportedReader(type);
+        if (source != null && valueReader != null)
+            return resolveAccessorsFromValueReader(source, configuration, valueReader);
+        else
+            return resolveProperties(type, true, configuration);
+    }
+
+    static <T> Map<String, Accessor> resolveAccessorsFromValueReader(T source,
+                                                                     InheritingConfiguration configuration, ValueReader<T> valueReader) {
+        Map<String, Accessor> accessors = new LinkedHashMap<String, Accessor>();
+        NameTransformer nameTransformer = configuration.getSourceNameTransformer();
+        for (String memberName : valueReader.memberNames(source)) {
+            ValueReader.Member<?> member = valueReader.getMember(source, memberName);
+            if (member != null)
+                accessors.put(nameTransformer.transform(memberName, NameableType.GENERIC),
+                        PropertyInfoImpl.ValueReaderPropertyInfo.fromMember(member, memberName));
+        }
+        return accessors;
+    }
+
+    static <T> Map<String, Mutator> resolveMutators(Class<T> type, InheritingConfiguration configuration) {
+        ValueWriter<T> valueWriter = configuration.valueMutateStore.getFirstSupportedWriter(type);
+        if (valueWriter != null && valueWriter.isResolveMembersSupport())
+            return resolveMutatorsFromValueWriter(type, configuration, valueWriter);
+        return resolveProperties(type, false, configuration);
+    }
+
+    static <T> Map<String, Mutator> resolveMutatorsFromValueWriter(Class<T> type,
+                                                                   InheritingConfiguration configuration, ValueWriter<T> valueWriter) {
+        Map<String, Mutator> mutators = new LinkedHashMap<String, Mutator>();
+        NameTransformer nameTransformer = configuration.getSourceNameTransformer();
+        for (String memberName : valueWriter.memberNames(type)) {
+            ValueWriter.Member<?> member = valueWriter.getMember(type, memberName);
+            if (member != null)
+                mutators.put(nameTransformer.transform(memberName, NameableType.GENERIC),
+                        PropertyInfoImpl.ValueWriterPropertyInfo.fromMember(member, memberName));
+        }
+        return mutators;
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private static <M extends AccessibleObject & Member, PI extends PropertyInfo> Map<String, PI> resolveProperties(
+            Class<?> type, boolean access, Configuration configuration) {
+        Map<String, PI> properties = new LinkedHashMap<String, PI>();
+        if (configuration.isFieldMatchingEnabled()) {
+            properties.putAll(resolveProperties(type, type, PropertyInfoSetResolver.<M, PI>resolveRequest(configuration, access, true)));
+        } else {
+            properties.putAll(resolveProperties(type, type, PropertyInfoSetResolver.<M, PI>resolveRequest(configuration, access, false)));
+        }
+        return properties;
+    }
+
+    /**
+     * Populates the {@code resolveRequest.propertyInfo} with {@code resolveRequest.propertyResolver}
+     * resolved property info for properties that are accessible by the
+     * {@code resolveRequest.accessLevel} and satisfy the {@code resolveRequest.namingConvention}.
+     * Uses a depth-first search so that child properties of the same name override parents.
+     */
+    private static <M extends AccessibleObject & Member, PI extends PropertyInfo> Map<String, PI> resolveProperties(
+            Class<?> initialType, Class<?> type, ResolveRequest<M, PI> resolveRequest) {
+        Map<String, PI> properties = new LinkedHashMap<String, PI>();
+        Class<?> superType = type.getSuperclass();
+        if (superType != null && superType != Object.class && superType != Enum.class)
+            properties.putAll(resolveProperties(initialType, superType, resolveRequest));
+
+        for (M member : resolveRequest.propertyResolver.membersFor(type)) {
+            if (canAccessMember(member, resolveRequest.accessLevel)
+                    && resolveRequest.propertyResolver.isValid(member)
+                    && resolveRequest.namingConvention.applies(member.getName(), resolveRequest.propertyType)) {
+                String name = resolveRequest.nameTransformer.transform(member.getName(),
+                        PropertyType.FIELD.equals(resolveRequest.propertyType) ? NameableType.FIELD
+                                : NameableType.METHOD);
+                PI info = resolveRequest.propertyResolver.propertyInfoFor(initialType, member,
+                        resolveRequest.config, name);
+                properties.put(name, info);
+
+                if (!Modifier.isPublic(member.getModifiers())
+                        || !Modifier.isPublic(member.getDeclaringClass().getModifiers()))
+                    try {
+                        member.setAccessible(true);
+                    } catch (SecurityException e) {
+                        throw new AssertionError(e);
+                    }
+            }
+        }
+
+        return properties;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <M extends AccessibleObject & Member, PI extends PropertyInfo> ResolveRequest<M, PI> resolveRequest(
+            Configuration configuration, boolean access, boolean field) {
+        ResolveRequest<M, PI> resolveRequest = new ResolveRequest<M, PI>();
+        resolveRequest.config = configuration;
+        if (access) {
+            resolveRequest.namingConvention = configuration.getSourceNamingConvention();
+            resolveRequest.nameTransformer = configuration.getSourceNameTransformer();
+        } else {
+            resolveRequest.namingConvention = configuration.getDestinationNamingConvention();
+            resolveRequest.nameTransformer = configuration.getDestinationNameTransformer();
+        }
+
+        if (field) {
+            resolveRequest.propertyType = PropertyType.FIELD;
+            resolveRequest.accessLevel = configuration.getFieldAccessLevel();
+            resolveRequest.propertyResolver = (PropertyInfoResolver<M, PI>) PropertyInfoResolver.FIELDS;
+        } else {
+            resolveRequest.propertyType = PropertyType.METHOD;
+            resolveRequest.accessLevel = configuration.getMethodAccessLevel();
+            resolveRequest.propertyResolver = (PropertyInfoResolver<M, PI>) (access ? PropertyInfoResolver.ACCESSORS
+                    : PropertyInfoResolver.MUTATORS);
+        }
+        return resolveRequest;
+    }
 }

--- a/core/src/test/java/org/modelmapper/internal/PropertyInfoSetResolverTest.java
+++ b/core/src/test/java/org/modelmapper/internal/PropertyInfoSetResolverTest.java
@@ -1,12 +1,18 @@
 package org.modelmapper.internal;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import org.modelmapper.config.Configuration.AccessLevel;
+import org.modelmapper.convention.NameTransformers;
+import org.modelmapper.convention.NamingConventions;
+import org.modelmapper.internal.valueaccess.ValueAccessStore;
+import org.modelmapper.spi.PropertyType;
+import org.testng.annotations.Test;
 
 import java.lang.reflect.Member;
+import java.util.Map;
 
-import org.modelmapper.config.Configuration.AccessLevel;
-import org.testng.annotations.Test;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
 
 /**
  * @author Jonathan Halterman
@@ -18,6 +24,74 @@ public class PropertyInfoSetResolverTest {
     protected int b;
     int c;
     @SuppressWarnings("unused") private int d;
+
+    public int getA() {
+      return a;
+    }
+
+    public void setA(int a) {
+      this.a = a;
+    }
+
+    public int getB() {
+      return b;
+    }
+
+    public void setB(int b) {
+      this.b = b;
+    }
+
+    public int getC() {
+      return c;
+    }
+
+    public void setC(int c) {
+      this.c = c;
+    }
+
+    public int getD() {
+      return d;
+    }
+
+    public void setD(int d) {
+      this.d = d;
+    }
+  }
+
+  public void whenIsFieldMatchingEnabledThenPropertyTypeShouldBeEqualsField() {
+    Members members = new Members();
+    InheritingConfiguration configuration = spy(new InheritingConfiguration());
+    when(configuration.isFieldMatchingEnabled()).thenReturn(true);
+    when(configuration.getFieldAccessLevel()).thenReturn(AccessLevel.PRIVATE);
+
+    when(configuration.getSourceNamingConvention()).thenReturn(NamingConventions.JAVABEANS_ACCESSOR);
+    when(configuration.getSourceNameTransformer()).thenReturn(NameTransformers.JAVABEANS_ACCESSOR);
+
+    Map<String, Accessor> accessors = PropertyInfoSetResolver
+            .resolveAccessors(members, Members.class, configuration);
+
+    assertEquals(accessors.get("a").getPropertyType(), PropertyType.FIELD);
+    assertEquals(accessors.get("b").getPropertyType(), PropertyType.FIELD);
+    assertEquals(accessors.get("c").getPropertyType(), PropertyType.FIELD);
+    assertEquals(accessors.get("d").getPropertyType(), PropertyType.FIELD);
+  }
+
+  public void whenIsNotFieldMatchingEnabledThenPropertyTypeShouldBeEqualsMethod() {
+    Members members = new Members();
+    InheritingConfiguration configuration = spy(new InheritingConfiguration());
+    when(configuration.isFieldMatchingEnabled()).thenReturn(false);
+    when(configuration.getFieldAccessLevel()).thenReturn(AccessLevel.PRIVATE);
+
+    when(configuration.getSourceNamingConvention()).thenReturn(NamingConventions.JAVABEANS_ACCESSOR);
+    when(configuration.getSourceNameTransformer()).thenReturn(NameTransformers.JAVABEANS_ACCESSOR);
+
+    Map<String, Accessor> accessors = PropertyInfoSetResolver
+            .resolveAccessors(members, Members.class, configuration);
+
+    assertEquals(accessors.get("a").getPropertyType(), PropertyType.METHOD);
+    assertEquals(accessors.get("b").getPropertyType(), PropertyType.METHOD);
+    assertEquals(accessors.get("c").getPropertyType(), PropertyType.METHOD);
+    assertEquals(accessors.get("d").getPropertyType(), PropertyType.METHOD);
   }
 
   public void testCanAccessMember() throws Exception {


### PR DESCRIPTION
A configuração `modelMapper.getConfiguration().setFieldMatchingEnabled(true)` era verificada, contudo, em seguida era feito um novo processo ignorando-a.