### PR TITLE
Correção na resolução do tipo de acessor de campo.

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/PropertyInfoSetResolver.java
+++ b/core/src/main/java/org/modelmapper/internal/PropertyInfoSetResolver.java
@@ -111,8 +111,9 @@ final class PropertyInfoSetResolver {
     Map<String, PI> properties = new LinkedHashMap<String, PI>();
     if (configuration.isFieldMatchingEnabled()) {
       properties.putAll(resolveProperties(type, type, PropertyInfoSetResolver.<M, PI>resolveRequest(configuration, access, true)));
+    } else {
+        properties.putAll(resolveProperties(type, type, PropertyInfoSetResolver.<M, PI>resolveRequest(configuration, access, false)));
     }
-    properties.putAll(resolveProperties(type, type, PropertyInfoSetResolver.<M, PI>resolveRequest(configuration, access, false)));
     return properties;
   }
 

--- a/core/src/test/java/org/modelmapper/internal/PropertyInfoSetResolverTest.java
+++ b/core/src/test/java/org/modelmapper/internal/PropertyInfoSetResolverTest.java
@@ -1,11 +1,17 @@
 package org.modelmapper.internal;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 import java.lang.reflect.Member;
+import java.util.Map;
 
 import org.modelmapper.config.Configuration.AccessLevel;
+import org.modelmapper.convention.NameTransformers;
+import org.modelmapper.convention.NamingConventions;
+import org.modelmapper.spi.PropertyType;
 import org.testng.annotations.Test;
 
 /**
@@ -18,6 +24,74 @@ public class PropertyInfoSetResolverTest {
     protected int b;
     int c;
     @SuppressWarnings("unused") private int d;
+
+    public int getA() {
+      return a;
+    }
+
+    public void setA(int a) {
+      this.a = a;
+    }
+
+    public int getB() {
+      return b;
+    }
+
+    public void setB(int b) {
+      this.b = b;
+    }
+
+    public int getC() {
+      return c;
+    }
+
+    public void setC(int c) {
+      this.c = c;
+    }
+
+    public int getD() {
+      return d;
+    }
+
+    public void setD(int d) {
+      this.d = d;
+    }
+  }
+
+  public void whenIsFieldMatchingEnabledThenPropertyTypeShouldBeEqualsField() {
+    Members members = new Members();
+    InheritingConfiguration configuration = spy(new InheritingConfiguration());
+    when(configuration.isFieldMatchingEnabled()).thenReturn(true);
+    when(configuration.getFieldAccessLevel()).thenReturn(AccessLevel.PRIVATE);
+
+    when(configuration.getSourceNamingConvention()).thenReturn(NamingConventions.JAVABEANS_ACCESSOR);
+    when(configuration.getSourceNameTransformer()).thenReturn(NameTransformers.JAVABEANS_ACCESSOR);
+
+    Map<String, Accessor> accessors = PropertyInfoSetResolver
+            .resolveAccessors(members, Members.class, configuration);
+
+    assertEquals(accessors.get("a").getPropertyType(), PropertyType.FIELD);
+    assertEquals(accessors.get("b").getPropertyType(), PropertyType.FIELD);
+    assertEquals(accessors.get("c").getPropertyType(), PropertyType.FIELD);
+    assertEquals(accessors.get("d").getPropertyType(), PropertyType.FIELD);
+  }
+
+  public void whenIsNotFieldMatchingEnabledThenPropertyTypeShouldBeEqualsMethod() {
+    Members members = new Members();
+    InheritingConfiguration configuration = spy(new InheritingConfiguration());
+    when(configuration.isFieldMatchingEnabled()).thenReturn(false);
+    when(configuration.getFieldAccessLevel()).thenReturn(AccessLevel.PRIVATE);
+
+    when(configuration.getSourceNamingConvention()).thenReturn(NamingConventions.JAVABEANS_ACCESSOR);
+    when(configuration.getSourceNameTransformer()).thenReturn(NameTransformers.JAVABEANS_ACCESSOR);
+
+    Map<String, Accessor> accessors = PropertyInfoSetResolver
+            .resolveAccessors(members, Members.class, configuration);
+
+    assertEquals(accessors.get("a").getPropertyType(), PropertyType.METHOD);
+    assertEquals(accessors.get("b").getPropertyType(), PropertyType.METHOD);
+    assertEquals(accessors.get("c").getPropertyType(), PropertyType.METHOD);
+    assertEquals(accessors.get("d").getPropertyType(), PropertyType.METHOD);
   }
 
   public void testCanAccessMember() throws Exception {


### PR DESCRIPTION
A configuração `modelMapper.getConfiguration().setFieldMatchingEnabled(true)` não estava fazendo efeito.  Ela era verificada e o processo feito corretamente. Porém, em seguida o processo era realizado novamente desconsiderando a configuração. A correção consiste na adição de uma instrução 'else'.