### PR TITLE
#564 - Bump ASM to version 9

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <cglib.version>3.2.9</cglib.version>
-    <asm.version>7.2</asm.version>
+    <asm.version>9.0</asm.version>
     <objenesis.version>2.6</objenesis.version>
     <typetools.version>0.6.2</typetools.version>
     <bytebuddy.version>1.9.4</bytebuddy.version>


### PR DESCRIPTION
This increases the asm version to version 9, the current one and fixes the problem described in [Issue 564](https://github.com/modelmapper/modelmapper/issues/564). 
I can provide a small POC project to demonstrate a) the problem and b) that it's resolved by this.
