### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 sudo: required
+cache:
+  directories:
+  - $HOME/.m2
 dist: trusty
 
 jdk:


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.