### PR TITLE
Eliminate warnings while defining explicit mapping on collections

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/ProxyFactory.java
+++ b/core/src/main/java/org/modelmapper/internal/ProxyFactory.java
@@ -23,6 +23,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Collection;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.NamingStrategy;
 import net.bytebuddy.description.method.MethodDescription;
@@ -77,12 +78,11 @@ class ProxyFactory {
   /**
    * @throws ErrorsException if the proxy for {@code type} cannot be generated or instantiated
    */
-  @SuppressWarnings("unchecked")
   static <T> T proxyFor(Class<T> type, InvocationHandler interceptor, Errors errors, boolean useOSGiClassLoaderBridging)
       throws ErrorsException {
     if (Primitives.isPrimitive(type))
       return Primitives.defaultValueForWrapper(type);
-    if (type.equals(String.class))
+    if (isProxyUnsupported(type))
       return null;
     if (Modifier.isFinal(type.getModifiers()))
       throw errors.invocationAgainstFinalClass(type).toException();
@@ -107,6 +107,10 @@ class ProxyFactory {
     } catch (Throwable t) {
       throw errors.errorInstantiatingProxy(type, t).toException();
     }
+  }
+
+  private static boolean isProxyUnsupported(Class<?> type) {
+    return type.equals(String.class) || Collection.class.isAssignableFrom(type);
   }
 
   private static <T> ClassLoadingStrategy<ClassLoader> chooseClassLoadingStrategy(Class<T> type) {


### PR DESCRIPTION
Jdk 9 and newer JDK display warning messages while we are trying to
proxy a java colleciton type java collection type. To fix this issue,
we just return null when we are proxy a collection type, because it's
useless to proxy a collection while defining an explicit mapping,

Resolved: #414