### PR TITLE
 Reduces redundant proxy to speed up setup explicit mappings

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/ConfigurableConditionExpressionImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/ConfigurableConditionExpressionImpl.java
@@ -33,9 +33,11 @@ import static org.modelmapper.internal.util.Assert.notNull;
 class ConfigurableConditionExpressionImpl<S, D> implements ConfigurableConditionExpression<S, D> {
   TypeMapImpl<S, D> typeMap;
   private MappingOptions options = new MappingOptions();
+  private final ReferenceMapExpressionImpl<S, D> expression;
 
   public ConfigurableConditionExpressionImpl(TypeMapImpl<S, D> typeMap) {
     this.typeMap = typeMap;
+    this.expression = new ReferenceMapExpressionImpl<S, D>(typeMap, options);
   }
 
   public ConfigurableConditionExpression<S, D> using(Converter<?, ?> converter) {
@@ -62,13 +64,11 @@ class ConfigurableConditionExpressionImpl<S, D> implements ConfigurableCondition
   public <V> void map(SourceGetter<S> sourceGetter, DestinationSetter<D, V> destinationSetter) {
     notNull(sourceGetter, "sourceGetter");
     notNull(destinationSetter, "destinationSetter");
-    new ReferenceMapExpressionImpl<S, D>(typeMap, options).map(sourceGetter, destinationSetter);
-    options = new MappingOptions();
+    expression.map(sourceGetter, destinationSetter);
   }
 
   public <V> void skip(DestinationSetter<D, V> destinationSetter) {
     notNull(destinationSetter, "destinationSetter");
-    new ReferenceMapExpressionImpl<S, D>(typeMap, options).skip(destinationSetter);
-    options = new MappingOptions();
+    expression.skip(destinationSetter);
   }
 }

--- a/core/src/main/java/org/modelmapper/internal/ExplicitMappingBuilder.java
+++ b/core/src/main/java/org/modelmapper/internal/ExplicitMappingBuilder.java
@@ -88,6 +88,14 @@ public class ExplicitMappingBuilder<S, D> implements ConditionExpression<S, D> {
     Provider<?> provider;
     int skipType;
     boolean mapFromSource;
+
+    void reset() {
+      condition = null;
+      converter = null;
+      provider = null;
+      skipType = 0;
+      mapFromSource = false;
+    }
   }
 
   static <S, D> Collection<MappingImpl> build(Class<S> sourceType, Class<D> destinationType,

--- a/core/src/main/java/org/modelmapper/internal/PropertyReferenceCollector.java
+++ b/core/src/main/java/org/modelmapper/internal/PropertyReferenceCollector.java
@@ -30,18 +30,18 @@ import org.modelmapper.spi.TypeSafeSourceGetter;
  * @author Chun Han Hsiao
  */
 class PropertyReferenceCollector {
-  private InheritingConfiguration config;
-  private ExplicitMappingBuilder.MappingOptions options;
-  private List<Accessor> accessors;
-  private List<Mutator> mutators;
+  private final InheritingConfiguration config;
+  private final ExplicitMappingBuilder.MappingOptions options;
+  private final List<Accessor> accessors;
+  private final List<Mutator> mutators;
 
   // This field will be set with a value if the mapping is map from source
   private Class<?> sourceType;
   // This field will be set with a value if the mapping is map from constant
   private Object constant;
 
-  private Errors errors;
-  private Errors proxyErrors;
+  private final Errors errors;
+  private final Errors proxyErrors;
 
   public static <S, D> List<Accessor> collect(TypeMapImpl<S, D> typeMap, TypeSafeSourceGetter<S, ?> sourceGetter) {
     PropertyReferenceCollector collector = new PropertyReferenceCollector(typeMap.configuration, null);
@@ -144,10 +144,16 @@ class PropertyReferenceCollector {
       errors.addMessage("Illegal DestinationSetter defined");
     errors.throwConfigurationExceptionIfErrorsExist();
     if (sourceType != null)
-      return new SourceMappingImpl(sourceType, mutators, options);
+      return new SourceMappingImpl(sourceType, new ArrayList<Mutator>(mutators), options);
     if (accessors.isEmpty())
-      return new ConstantMappingImpl(constant, mutators, options);
-    return new PropertyMappingImpl(accessors, mutators, options);
+      return new ConstantMappingImpl(constant, new ArrayList<Mutator>(mutators), options);
+    return new PropertyMappingImpl(new ArrayList<Accessor>(accessors), new ArrayList<Mutator>(mutators), options);
+  }
+
+  void reset() {
+    mutators.clear();
+    accessors.clear();
+    options.reset();
   }
 
   public Errors getErrors() {


### PR DESCRIPTION
Reflections are slow, reduces the calls can speed up modelmapper.

Resolved: #462