### PR TITLE
Add new option 'preferNestedProperties' for circular reference mapping

### DIFF
--- a/core/src/main/java/org/modelmapper/config/Configuration.java
+++ b/core/src/main/java/org/modelmapper/config/Configuration.java
@@ -230,6 +230,22 @@ public interface Configuration {
   boolean isImplicitMappingEnabled();
 
   /**
+   * Returns whether nested properties were preferred when ModelMapper were building the type map
+   * with implicit mapping. When {@code true} (default), ModelMapper will prefer looking for nested
+   * properties for a mapping definition.
+   *
+   * This option should be disabled when you are trying to map a model contains circular reference.
+   *
+   * <pre>
+   *  modelMapper.createTypeMap(SourceTree.class, DestinationTree.class,
+   *    modelMapper.getConfiguration().copy().setPreferNestedProperties(false));
+   * </pre>
+   *
+   * @see #setPreferNestedProperties(boolean)
+   */
+  boolean isPreferNestedProperties();
+
+  /**
    * Returns whether a property mapping will be skipped if the property value is {@code null}.
    * When {@code true}, ModelMapper will always not set {@code null} to destination property.
    *
@@ -342,6 +358,23 @@ public interface Configuration {
    * @see #isImplicitMappingEnabled()
    */
   Configuration setImplicitMappingEnabled(boolean enabled);
+
+  /**
+   * Sets whether nested properties were preferred when ModelMapper were building the type map with
+   * implicit mapping. When {@code true} (default), ModelMapper will prefer looking for nested
+   * properties for a mapping definition.
+   *
+   * This option should be disabled when you are trying to map a model contains circular reference.
+   *
+   * <pre>
+   *  modelMapper.createTypeMap(SourceTree.class, DestinationTree.class,
+   *    modelMapper.getConfiguration().copy().setPreferNestedProperties(false));
+   * </pre>
+   *
+   * @param enabled whether prefer nested properties
+   * @see #isPreferNestedProperties()
+   */
+  Configuration setPreferNestedProperties(boolean enabled);
 
   /**
    * Sets whether a property should be skipped or not when the property value is {@code null}.

--- a/core/src/main/java/org/modelmapper/internal/ImplicitMappingBuilder.java
+++ b/core/src/main/java/org/modelmapper/internal/ImplicitMappingBuilder.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import org.modelmapper.Converter;
 import org.modelmapper.TypeMap;
+import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.internal.PropertyInfoImpl.ValueReaderPropertyInfo;
 import org.modelmapper.internal.converter.ConverterStore;
 import org.modelmapper.internal.util.Iterables;
@@ -172,10 +173,13 @@ class ImplicitMappingBuilder<S, D> {
       boolean doneMatching = false;
 
       if (matchingStrategy.matches(propertyNameInfo)) {
-        if (destinationTypes.contains(destinationMutator.getType())) {
+        if (destinationTypes.contains(destinationMutator.getType()))
           mappings.add(new PropertyMappingImpl(propertyNameInfo.getSourceProperties(),
               propertyNameInfo.getDestinationProperties(), true));
-        } else {
+        else if (!configuration.isPreferNestedProperties() && MatchingStrategies.STRICT.matches(propertyNameInfo))
+          mappings.add(new PropertyMappingImpl(propertyNameInfo.getSourceProperties(),
+              propertyNameInfo.getDestinationProperties(), false));
+        else {
           TypeMap<?, ?> propertyTypeMap = typeMapStore.get(accessor.getType(),
               destinationMutator.getType(), null);
           PropertyMappingImpl mapping = null;

--- a/core/src/main/java/org/modelmapper/internal/InheritingConfiguration.java
+++ b/core/src/main/java/org/modelmapper/internal/InheritingConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.modelmapper.internal;
 
+import java.util.List;
+
 import org.modelmapper.Condition;
 import org.modelmapper.Provider;
 import org.modelmapper.config.Configuration;
@@ -29,9 +31,13 @@ import org.modelmapper.internal.converter.NonMergingCollectionConverter;
 import org.modelmapper.internal.util.Assert;
 import org.modelmapper.internal.valueaccess.ValueAccessStore;
 import org.modelmapper.internal.valuemutate.ValueMutateStore;
-import org.modelmapper.spi.*;
-
-import java.util.List;
+import org.modelmapper.spi.ConditionalConverter;
+import org.modelmapper.spi.MatchingStrategy;
+import org.modelmapper.spi.NameTokenizer;
+import org.modelmapper.spi.NameTransformer;
+import org.modelmapper.spi.NamingConvention;
+import org.modelmapper.spi.ValueReader;
+import org.modelmapper.spi.ValueWriter;
 
 /**
  * Inheritable mapping configuration implementation.
@@ -59,6 +65,7 @@ public class InheritingConfiguration implements Configuration {
   private Boolean ambiguityIgnored;
   private Boolean fullTypeMatchingRequired;
   private Boolean implicitMatchingEnabled;
+  private Boolean preferNestedProperties;
   private Boolean skipNullEnabled;
   private Boolean collectionsMergeEnabled;
   private Boolean useOSGiClassLoaderBridging;
@@ -85,6 +92,7 @@ public class InheritingConfiguration implements Configuration {
     ambiguityIgnored = Boolean.FALSE;
     fullTypeMatchingRequired = Boolean.FALSE;
     implicitMatchingEnabled = Boolean.TRUE;
+    preferNestedProperties = Boolean.TRUE;
     skipNullEnabled = Boolean.FALSE;
     useOSGiClassLoaderBridging = Boolean.FALSE;
     collectionsMergeEnabled = Boolean.TRUE;
@@ -119,6 +127,7 @@ public class InheritingConfiguration implements Configuration {
       propertyCondition = source.propertyCondition;
       fullTypeMatchingRequired = source.fullTypeMatchingRequired;
       implicitMatchingEnabled = source.implicitMatchingEnabled;
+      preferNestedProperties = source.preferNestedProperties;
       skipNullEnabled = source.skipNullEnabled;
       collectionsMergeEnabled = source.collectionsMergeEnabled;
     }
@@ -307,6 +316,13 @@ public class InheritingConfiguration implements Configuration {
   }
 
   @Override
+  public boolean isPreferNestedProperties() {
+    return preferNestedProperties == null
+        ? Assert.notNull(parent).isPreferNestedProperties()
+        : preferNestedProperties;
+  }
+
+  @Override
   public boolean isSkipNullEnabled() {
     return skipNullEnabled == null
         ? Assert.notNull(parent).isSkipNullEnabled()
@@ -375,6 +391,12 @@ public class InheritingConfiguration implements Configuration {
   @Override
   public Configuration setImplicitMappingEnabled(boolean enabled) {
     implicitMatchingEnabled = enabled;
+    return this;
+  }
+
+  @Override
+  public Configuration setPreferNestedProperties(boolean enabled) {
+    preferNestedProperties = enabled;
     return this;
   }
 

--- a/core/src/test/java/org/modelmapper/bugs/GH565.java
+++ b/core/src/test/java/org/modelmapper/bugs/GH565.java
@@ -1,0 +1,82 @@
+package org.modelmapper.bugs;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.modelmapper.AbstractTest;
+import org.testng.annotations.Test;
+
+@Test
+public class GH565 extends AbstractTest {
+
+  public void shouldMap() {
+    DBBoardNode dbNode1 = new DBBoardNode();
+    DBBoardNode dbNode2 = new DBBoardNode();
+    DBChessBoard dbChessBoard = new DBChessBoard();
+    dbChessBoard.nodes = Arrays.asList(dbNode1, dbNode2);
+    DBPlayer source = new DBPlayer();
+    source.favoriteTile = dbNode2;
+    source.favoritePiece = new DBChessPiece();
+    source.favoritePiece.node = dbNode1;
+    dbNode1.pieces = Collections.singletonList(source.favoritePiece);
+    dbNode1.board = dbChessBoard;
+    dbNode2.board = dbChessBoard;
+
+    modelMapper.getConfiguration().setPreferNestedProperties(false);
+    Player target = modelMapper.map(source, Player.class);
+
+    assertEquals(target.favoriteTile.board.nodes.size(), 2);
+    BoardNode node1 = target.favoriteTile.board.nodes.get(0);
+    BoardNode node2 = target.favoriteTile.board.nodes.get(1);
+    assertSame(target.favoriteTile, node2);
+    assertSame(target.favoritePiece.node, node1);
+    assertSame(node1.board, node2.board);
+    assertSame(node1.pieces.get(0), target.favoritePiece);
+  }
+
+  private static class DBPlayer {
+    DBBoardNode favoriteTile;
+    DBChessPiece favoritePiece;
+  }
+
+  private static class DBBoardNode {
+    List<DBChessPiece> pieces;
+    DBChessBoard board;
+    int x;
+    int y;
+  }
+
+  private static class DBChessPiece {
+    String id;
+    DBBoardNode node;
+  }
+
+  private static class DBChessBoard {
+    List<DBBoardNode> nodes;
+  }
+
+  private static class Player {
+    BoardNode favoriteTile;
+    ChessPiece favoritePiece;
+  }
+
+  private static class BoardNode {
+    List<ChessPiece> pieces;
+    ChessBoard board;
+    int x;
+    int y;
+  }
+
+  private static class ChessPiece {
+    String id;
+    BoardNode node;
+  }
+
+  private static class ChessBoard {
+    List<BoardNode> nodes;
+  }
+}

--- a/core/src/test/java/org/modelmapper/internal/DisablePreferNestedPropertiesTest.java
+++ b/core/src/test/java/org/modelmapper/internal/DisablePreferNestedPropertiesTest.java
@@ -1,0 +1,120 @@
+package org.modelmapper.internal;
+
+import static org.testng.Assert.assertEquals;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.TypeMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test
+public class DisablePreferNestedPropertiesTest extends AbstractTest {
+
+  @BeforeMethod
+  public void setUp() {
+    modelMapper.getConfiguration().setPreferNestedProperties(false);
+  }
+
+  public void shouldFlattenWhileDisablePreferNestedProperties() {
+    TypeMap<Order, OrderDto> typeMap = modelMapper.typeMap(Order.class, OrderDto.class);
+    typeMap.validate();
+    assertEquals(typeMap.getMappings().size(), 4);
+
+    OrderDto destination = modelMapper.map(Order.newInstance(), OrderDto.class);
+    OrderDto expected = OrderDto.newInstance();
+    assertEquals(destination.customerFirstName, expected.customerFirstName);
+    assertEquals(destination.customerLastName, expected.customerLastName);
+    assertEquals(destination.billingCity, expected.billingCity);
+    assertEquals(destination.billingStreet, expected.billingStreet);
+  }
+
+  public void shouldMapFromFlatten() {
+    TypeMap<OrderDto, Order> typeMap = modelMapper.typeMap(OrderDto.class, Order.class);
+    typeMap.validate();
+    assertEquals(typeMap.getMappings().size(), 4);
+
+    Order destination = modelMapper.map(OrderDto.newInstance(), Order.class);
+    Order expected = Order.newInstance();
+    assertEquals(destination.customer.firstName, expected.customer.firstName);
+    assertEquals(destination.customer.lastName, expected.customer.lastName);
+    assertEquals(destination.billing.city, expected.billing.city);
+    assertEquals(destination.billing.street, expected.billing.street);
+  }
+
+  public void shouldMapToFlattenParentId() {
+    TypeMap<Category, CategoryDto> typeMap = modelMapper.typeMap(Category.class, CategoryDto.class);
+    typeMap.validate();
+    assertEquals(typeMap.getMappings().size(), 2);
+
+    CategoryDto destination = modelMapper.map(Category.newInstance(), CategoryDto.class);
+    assertEquals(destination.id, 2);
+    assertEquals(destination.parentId, 1);
+  }
+
+  private static class Order {
+    Customer customer;
+    Address billing;
+
+    private static Order newInstance() {
+      Order order = new Order();
+      order.customer = new Customer();
+      order.customer.firstName = "First";
+      order.customer.lastName = "Last";
+      order.billing = new Address();
+      order.billing.city = "City";
+      order.billing.street = "Street";
+      return order;
+    }
+  }
+
+  private static class Customer {
+    String firstName;
+    String lastName;
+  }
+
+  private static class Address {
+    String street;
+    String city;
+  }
+
+  private static class OrderDto {
+    String customerFirstName;
+    String customerLastName;
+    String billingStreet;
+    String billingCity;
+
+    private static OrderDto newInstance() {
+      OrderDto order = new OrderDto();
+      order.customerFirstName = "First";
+      order.customerLastName = "Last";
+      order.billingCity = "City";
+      order.billingStreet = "Street";
+      return order;
+    }
+  }
+
+  private static class Category {
+    long id;
+    Category parent;
+
+    public static Category newInstance() {
+      Category category = new Category();
+      category.id = 2;
+      category.parent = new Category();
+      category.parent.id = 1;
+      return category;
+    }
+  }
+
+  private static class CategoryDto {
+    long id;
+    long parentId;
+
+    public static CategoryDto newInstance() {
+      CategoryDto category = new CategoryDto();
+      category.id = 2;
+      category.parentId = 1;
+      return category;
+    }
+  }
+}


### PR DESCRIPTION
It's too complex to map nested properties for circular reference models.
We provides an option to disable the nested properties mapping when user
wants to map a circular reference models.

Resolved: #565