### PR TITLE
Type map store lookup fix for enums with anonymous class

### DIFF
--- a/core/src/test/java/org/modelmapper/functional/enums/EnumWithAnonymousClassMapTest.java
+++ b/core/src/test/java/org/modelmapper/functional/enums/EnumWithAnonymousClassMapTest.java
@@ -1,0 +1,44 @@
+package org.modelmapper.functional.enums;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.Converter;
+import org.modelmapper.spi.MappingContext;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(groups = "functional")
+public class EnumWithAnonymousClassMapTest extends AbstractTest {
+
+  enum Source {
+    a,
+    b,
+    c {
+      @Override
+      public boolean isUnique() {
+        return true;
+      }
+    };
+
+    public boolean isUnique() {
+      return false;
+    }
+  }
+
+  enum Dest {
+    ordinary, unique
+  }
+
+  public void testConvertEnumWithAnonymousClass() {
+    modelMapper.addConverter(new Converter<Source, Dest>() {
+      @Override
+      public Dest convert(MappingContext<Source, Dest> context) {
+        return context.getSource().isUnique() ? Dest.unique : Dest.ordinary;
+      }
+    });
+
+    assertEquals(modelMapper.map(Source.a, Dest.class), Dest.ordinary);
+    assertEquals(modelMapper.map(Source.c, Dest.class), Dest.unique);
+  }
+
+}


### PR DESCRIPTION
When the source of mapping is an instance of an enum with some methods overridden, the source is essentially an extension anonymous class of an original enum. For such sources, type map lookup doesn't return the desired instance. It leads to unexpected mapping results. 

Please see the test case at
https://github.com/modelmapper/modelmapper/pull/617/commits/3bebc4e0616694b701e0449ee2b743b838d0c34f#diff-7bb3714c07d31f0e6def4190141b1fcd3a7a2cdb1b2a8bee81f17b6a1550a73dR11