### PR TITLE
Improve performance on implicit mapping

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>modelmapper-parent</artifactId>
+    <groupId>org.modelmapper</groupId>
+    <version>2.4.5-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>benchmarks</artifactId>
+  <name>ModelMapper Benchmarks</name>
+
+  <properties>
+    <jmh.version>1.32</jmh.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.modelmapper</groupId>
+      <artifactId>modelmapper</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.2</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/benchmarks/src/main/java/org/modelmapper/benchmarks/GiantModelBenchmark.java
+++ b/benchmarks/src/main/java/org/modelmapper/benchmarks/GiantModelBenchmark.java
@@ -1,0 +1,33 @@
+package org.modelmapper.benchmarks;
+
+import org.modelmapper.ModelMapper;
+import org.modelmapper.benchmarks.model.GiantDto;
+import org.modelmapper.benchmarks.model.GiantEntity;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class GiantModelBenchmark {
+
+  @Benchmark
+  public void measureSubclass() {
+    Class<? extends GiantEntity> sourceType = new GiantEntity() {}.getClass();
+    Class<? extends GiantDto> destType = new GiantDto() {}.getClass();
+    new ModelMapper().createTypeMap(sourceType, destType);
+  }
+
+  @Benchmark
+  public void measure() {
+    new ModelMapper().createTypeMap(GiantEntity.class, GiantDto.class);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options options = new OptionsBuilder()
+        .include(GiantModelBenchmark.class.getSimpleName())
+        .forks(1)
+        .build();
+    new Runner(options).run();
+  }
+}

--- a/benchmarks/src/main/java/org/modelmapper/benchmarks/Main.java
+++ b/benchmarks/src/main/java/org/modelmapper/benchmarks/Main.java
@@ -1,0 +1,13 @@
+package org.modelmapper.benchmarks;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.CommandLineOptionException;
+import org.openjdk.jmh.runner.options.CommandLineOptions;
+
+public class Main {
+
+  public static void main(String[] args) throws CommandLineOptionException, RunnerException {
+    new Runner(new CommandLineOptions(args)).run();
+  }
+}

--- a/benchmarks/src/main/java/org/modelmapper/benchmarks/model/GiantDto.java
+++ b/benchmarks/src/main/java/org/modelmapper/benchmarks/model/GiantDto.java
@@ -1,0 +1,629 @@
+package org.modelmapper.benchmarks.model;
+
+import java.util.List;
+
+public class GiantDto {
+  private String field1;
+  private String field2;
+  private String field3;
+  private String field4;
+  private String field5;
+  private String field6;
+  private String field7;
+  private String field8;
+  private String field9;
+  private String field10;
+  private String field11;
+  private String field12;
+  private String field13;
+  private String field14;
+  private String field15;
+  private String field16;
+  private String field17;
+  private String field18;
+  private String field19;
+  private String field20;
+  private String field21;
+  private String field22;
+  private String field23;
+  private String field24;
+  private String field25;
+  private String field26;
+  private String field27;
+  private String field28;
+  private String field29;
+  private String field30;
+  private String field31;
+  private String field32;
+  private String field33;
+  private String field34;
+  private String field35;
+  private String field36;
+  private String field37;
+  private String field38;
+  private String field39;
+  private String field40;
+  private String field41;
+  private String field42;
+  private String field43;
+  private String field44;
+  private String field45;
+  private String field46;
+  private String field47;
+  private String field48;
+  private String field49;
+  private String field50;
+
+  private List<GiantFieldDto> fields1;
+  private List<GiantFieldDto> fields2;
+  private List<GiantFieldDto> fields3;
+  private List<GiantFieldDto> fields4;
+  private List<GiantFieldDto> fields5;
+  private List<GiantFieldDto> fields6;
+  private List<GiantFieldDto> fields7;
+  private List<GiantFieldDto> fields8;
+  private List<GiantFieldDto> fields9;
+  private List<GiantFieldDto> fields10;
+  private List<GiantFieldDto> fields11;
+  private List<GiantFieldDto> fields12;
+  private List<GiantFieldDto> fields13;
+  private List<GiantFieldDto> fields14;
+  private List<GiantFieldDto> fields15;
+  private List<GiantFieldDto> fields16;
+  private List<GiantFieldDto> fields17;
+  private List<GiantFieldDto> fields18;
+  private List<GiantFieldDto> fields19;
+  private List<GiantFieldDto> fields20;
+
+  public String getField1() {
+    return field1;
+  }
+
+  public void setField1(String field1) {
+    this.field1 = field1;
+  }
+
+  public String getField2() {
+    return field2;
+  }
+
+  public void setField2(String field2) {
+    this.field2 = field2;
+  }
+
+  public String getField3() {
+    return field3;
+  }
+
+  public void setField3(String field3) {
+    this.field3 = field3;
+  }
+
+  public String getField4() {
+    return field4;
+  }
+
+  public void setField4(String field4) {
+    this.field4 = field4;
+  }
+
+  public String getField5() {
+    return field5;
+  }
+
+  public void setField5(String field5) {
+    this.field5 = field5;
+  }
+
+  public String getField6() {
+    return field6;
+  }
+
+  public void setField6(String field6) {
+    this.field6 = field6;
+  }
+
+  public String getField7() {
+    return field7;
+  }
+
+  public void setField7(String field7) {
+    this.field7 = field7;
+  }
+
+  public String getField8() {
+    return field8;
+  }
+
+  public void setField8(String field8) {
+    this.field8 = field8;
+  }
+
+  public String getField9() {
+    return field9;
+  }
+
+  public void setField9(String field9) {
+    this.field9 = field9;
+  }
+
+  public String getField10() {
+    return field10;
+  }
+
+  public void setField10(String field10) {
+    this.field10 = field10;
+  }
+
+  public String getField11() {
+    return field11;
+  }
+
+  public void setField11(String field11) {
+    this.field11 = field11;
+  }
+
+  public String getField12() {
+    return field12;
+  }
+
+  public void setField12(String field12) {
+    this.field12 = field12;
+  }
+
+  public String getField13() {
+    return field13;
+  }
+
+  public void setField13(String field13) {
+    this.field13 = field13;
+  }
+
+  public String getField14() {
+    return field14;
+  }
+
+  public void setField14(String field14) {
+    this.field14 = field14;
+  }
+
+  public String getField15() {
+    return field15;
+  }
+
+  public void setField15(String field15) {
+    this.field15 = field15;
+  }
+
+  public String getField16() {
+    return field16;
+  }
+
+  public void setField16(String field16) {
+    this.field16 = field16;
+  }
+
+  public String getField17() {
+    return field17;
+  }
+
+  public void setField17(String field17) {
+    this.field17 = field17;
+  }
+
+  public String getField18() {
+    return field18;
+  }
+
+  public void setField18(String field18) {
+    this.field18 = field18;
+  }
+
+  public String getField19() {
+    return field19;
+  }
+
+  public void setField19(String field19) {
+    this.field19 = field19;
+  }
+
+  public String getField20() {
+    return field20;
+  }
+
+  public void setField20(String field20) {
+    this.field20 = field20;
+  }
+
+  public String getField21() {
+    return field21;
+  }
+
+  public void setField21(String field21) {
+    this.field21 = field21;
+  }
+
+  public String getField22() {
+    return field22;
+  }
+
+  public void setField22(String field22) {
+    this.field22 = field22;
+  }
+
+  public String getField23() {
+    return field23;
+  }
+
+  public void setField23(String field23) {
+    this.field23 = field23;
+  }
+
+  public String getField24() {
+    return field24;
+  }
+
+  public void setField24(String field24) {
+    this.field24 = field24;
+  }
+
+  public String getField25() {
+    return field25;
+  }
+
+  public void setField25(String field25) {
+    this.field25 = field25;
+  }
+
+  public String getField26() {
+    return field26;
+  }
+
+  public void setField26(String field26) {
+    this.field26 = field26;
+  }
+
+  public String getField27() {
+    return field27;
+  }
+
+  public void setField27(String field27) {
+    this.field27 = field27;
+  }
+
+  public String getField28() {
+    return field28;
+  }
+
+  public void setField28(String field28) {
+    this.field28 = field28;
+  }
+
+  public String getField29() {
+    return field29;
+  }
+
+  public void setField29(String field29) {
+    this.field29 = field29;
+  }
+
+  public String getField30() {
+    return field30;
+  }
+
+  public void setField30(String field30) {
+    this.field30 = field30;
+  }
+
+  public String getField31() {
+    return field31;
+  }
+
+  public void setField31(String field31) {
+    this.field31 = field31;
+  }
+
+  public String getField32() {
+    return field32;
+  }
+
+  public void setField32(String field32) {
+    this.field32 = field32;
+  }
+
+  public String getField33() {
+    return field33;
+  }
+
+  public void setField33(String field33) {
+    this.field33 = field33;
+  }
+
+  public String getField34() {
+    return field34;
+  }
+
+  public void setField34(String field34) {
+    this.field34 = field34;
+  }
+
+  public String getField35() {
+    return field35;
+  }
+
+  public void setField35(String field35) {
+    this.field35 = field35;
+  }
+
+  public String getField36() {
+    return field36;
+  }
+
+  public void setField36(String field36) {
+    this.field36 = field36;
+  }
+
+  public String getField37() {
+    return field37;
+  }
+
+  public void setField37(String field37) {
+    this.field37 = field37;
+  }
+
+  public String getField38() {
+    return field38;
+  }
+
+  public void setField38(String field38) {
+    this.field38 = field38;
+  }
+
+  public String getField39() {
+    return field39;
+  }
+
+  public void setField39(String field39) {
+    this.field39 = field39;
+  }
+
+  public String getField40() {
+    return field40;
+  }
+
+  public void setField40(String field40) {
+    this.field40 = field40;
+  }
+
+  public String getField41() {
+    return field41;
+  }
+
+  public void setField41(String field41) {
+    this.field41 = field41;
+  }
+
+  public String getField42() {
+    return field42;
+  }
+
+  public void setField42(String field42) {
+    this.field42 = field42;
+  }
+
+  public String getField43() {
+    return field43;
+  }
+
+  public void setField43(String field43) {
+    this.field43 = field43;
+  }
+
+  public String getField44() {
+    return field44;
+  }
+
+  public void setField44(String field44) {
+    this.field44 = field44;
+  }
+
+  public String getField45() {
+    return field45;
+  }
+
+  public void setField45(String field45) {
+    this.field45 = field45;
+  }
+
+  public String getField46() {
+    return field46;
+  }
+
+  public void setField46(String field46) {
+    this.field46 = field46;
+  }
+
+  public String getField47() {
+    return field47;
+  }
+
+  public void setField47(String field47) {
+    this.field47 = field47;
+  }
+
+  public String getField48() {
+    return field48;
+  }
+
+  public void setField48(String field48) {
+    this.field48 = field48;
+  }
+
+  public String getField49() {
+    return field49;
+  }
+
+  public void setField49(String field49) {
+    this.field49 = field49;
+  }
+
+  public String getField50() {
+    return field50;
+  }
+
+  public void setField50(String field50) {
+    this.field50 = field50;
+  }
+
+  public List<GiantFieldDto> getFields1() {
+    return fields1;
+  }
+
+  public void setFields1(List<GiantFieldDto> fields1) {
+    this.fields1 = fields1;
+  }
+
+  public List<GiantFieldDto> getFields2() {
+    return fields2;
+  }
+
+  public void setFields2(List<GiantFieldDto> fields2) {
+    this.fields2 = fields2;
+  }
+
+  public List<GiantFieldDto> getFields3() {
+    return fields3;
+  }
+
+  public void setFields3(List<GiantFieldDto> fields3) {
+    this.fields3 = fields3;
+  }
+
+  public List<GiantFieldDto> getFields4() {
+    return fields4;
+  }
+
+  public void setFields4(List<GiantFieldDto> fields4) {
+    this.fields4 = fields4;
+  }
+
+  public List<GiantFieldDto> getFields5() {
+    return fields5;
+  }
+
+  public void setFields5(List<GiantFieldDto> fields5) {
+    this.fields5 = fields5;
+  }
+
+  public List<GiantFieldDto> getFields6() {
+    return fields6;
+  }
+
+  public void setFields6(List<GiantFieldDto> fields6) {
+    this.fields6 = fields6;
+  }
+
+  public List<GiantFieldDto> getFields7() {
+    return fields7;
+  }
+
+  public void setFields7(List<GiantFieldDto> fields7) {
+    this.fields7 = fields7;
+  }
+
+  public List<GiantFieldDto> getFields8() {
+    return fields8;
+  }
+
+  public void setFields8(List<GiantFieldDto> fields8) {
+    this.fields8 = fields8;
+  }
+
+  public List<GiantFieldDto> getFields9() {
+    return fields9;
+  }
+
+  public void setFields9(List<GiantFieldDto> fields9) {
+    this.fields9 = fields9;
+  }
+
+  public List<GiantFieldDto> getFields10() {
+    return fields10;
+  }
+
+  public void setFields10(List<GiantFieldDto> fields10) {
+    this.fields10 = fields10;
+  }
+
+  public List<GiantFieldDto> getFields11() {
+    return fields11;
+  }
+
+  public void setFields11(List<GiantFieldDto> fields11) {
+    this.fields11 = fields11;
+  }
+
+  public List<GiantFieldDto> getFields12() {
+    return fields12;
+  }
+
+  public void setFields12(List<GiantFieldDto> fields12) {
+    this.fields12 = fields12;
+  }
+
+  public List<GiantFieldDto> getFields13() {
+    return fields13;
+  }
+
+  public void setFields13(List<GiantFieldDto> fields13) {
+    this.fields13 = fields13;
+  }
+
+  public List<GiantFieldDto> getFields14() {
+    return fields14;
+  }
+
+  public void setFields14(List<GiantFieldDto> fields14) {
+    this.fields14 = fields14;
+  }
+
+  public List<GiantFieldDto> getFields15() {
+    return fields15;
+  }
+
+  public void setFields15(List<GiantFieldDto> fields15) {
+    this.fields15 = fields15;
+  }
+
+  public List<GiantFieldDto> getFields16() {
+    return fields16;
+  }
+
+  public void setFields16(List<GiantFieldDto> fields16) {
+    this.fields16 = fields16;
+  }
+
+  public List<GiantFieldDto> getFields17() {
+    return fields17;
+  }
+
+  public void setFields17(List<GiantFieldDto> fields17) {
+    this.fields17 = fields17;
+  }
+
+  public List<GiantFieldDto> getFields18() {
+    return fields18;
+  }
+
+  public void setFields18(List<GiantFieldDto> fields18) {
+    this.fields18 = fields18;
+  }
+
+  public List<GiantFieldDto> getFields19() {
+    return fields19;
+  }
+
+  public void setFields19(List<GiantFieldDto> fields19) {
+    this.fields19 = fields19;
+  }
+}

--- a/benchmarks/src/main/java/org/modelmapper/benchmarks/model/GiantEntity.java
+++ b/benchmarks/src/main/java/org/modelmapper/benchmarks/model/GiantEntity.java
@@ -1,0 +1,629 @@
+package org.modelmapper.benchmarks.model;
+
+import java.util.List;
+
+public class GiantEntity {
+  private String field1;
+  private String field2;
+  private String field3;
+  private String field4;
+  private String field5;
+  private String field6;
+  private String field7;
+  private String field8;
+  private String field9;
+  private String field10;
+  private String field11;
+  private String field12;
+  private String field13;
+  private String field14;
+  private String field15;
+  private String field16;
+  private String field17;
+  private String field18;
+  private String field19;
+  private String field20;
+  private String field21;
+  private String field22;
+  private String field23;
+  private String field24;
+  private String field25;
+  private String field26;
+  private String field27;
+  private String field28;
+  private String field29;
+  private String field30;
+  private String field31;
+  private String field32;
+  private String field33;
+  private String field34;
+  private String field35;
+  private String field36;
+  private String field37;
+  private String field38;
+  private String field39;
+  private String field40;
+  private String field41;
+  private String field42;
+  private String field43;
+  private String field44;
+  private String field45;
+  private String field46;
+  private String field47;
+  private String field48;
+  private String field49;
+  private String field50;
+
+  private List<GiantFieldDto> fields1;
+  private List<GiantFieldDto> fields2;
+  private List<GiantFieldDto> fields3;
+  private List<GiantFieldDto> fields4;
+  private List<GiantFieldDto> fields5;
+  private List<GiantFieldDto> fields6;
+  private List<GiantFieldDto> fields7;
+  private List<GiantFieldDto> fields8;
+  private List<GiantFieldDto> fields9;
+  private List<GiantFieldDto> fields10;
+  private List<GiantFieldDto> fields11;
+  private List<GiantFieldDto> fields12;
+  private List<GiantFieldDto> fields13;
+  private List<GiantFieldDto> fields14;
+  private List<GiantFieldDto> fields15;
+  private List<GiantFieldDto> fields16;
+  private List<GiantFieldDto> fields17;
+  private List<GiantFieldDto> fields18;
+  private List<GiantFieldDto> fields19;
+  private List<GiantFieldDto> fields20;
+
+  public String getField1() {
+    return field1;
+  }
+
+  public void setField1(String field1) {
+    this.field1 = field1;
+  }
+
+  public String getField2() {
+    return field2;
+  }
+
+  public void setField2(String field2) {
+    this.field2 = field2;
+  }
+
+  public String getField3() {
+    return field3;
+  }
+
+  public void setField3(String field3) {
+    this.field3 = field3;
+  }
+
+  public String getField4() {
+    return field4;
+  }
+
+  public void setField4(String field4) {
+    this.field4 = field4;
+  }
+
+  public String getField5() {
+    return field5;
+  }
+
+  public void setField5(String field5) {
+    this.field5 = field5;
+  }
+
+  public String getField6() {
+    return field6;
+  }
+
+  public void setField6(String field6) {
+    this.field6 = field6;
+  }
+
+  public String getField7() {
+    return field7;
+  }
+
+  public void setField7(String field7) {
+    this.field7 = field7;
+  }
+
+  public String getField8() {
+    return field8;
+  }
+
+  public void setField8(String field8) {
+    this.field8 = field8;
+  }
+
+  public String getField9() {
+    return field9;
+  }
+
+  public void setField9(String field9) {
+    this.field9 = field9;
+  }
+
+  public String getField10() {
+    return field10;
+  }
+
+  public void setField10(String field10) {
+    this.field10 = field10;
+  }
+
+  public String getField11() {
+    return field11;
+  }
+
+  public void setField11(String field11) {
+    this.field11 = field11;
+  }
+
+  public String getField12() {
+    return field12;
+  }
+
+  public void setField12(String field12) {
+    this.field12 = field12;
+  }
+
+  public String getField13() {
+    return field13;
+  }
+
+  public void setField13(String field13) {
+    this.field13 = field13;
+  }
+
+  public String getField14() {
+    return field14;
+  }
+
+  public void setField14(String field14) {
+    this.field14 = field14;
+  }
+
+  public String getField15() {
+    return field15;
+  }
+
+  public void setField15(String field15) {
+    this.field15 = field15;
+  }
+
+  public String getField16() {
+    return field16;
+  }
+
+  public void setField16(String field16) {
+    this.field16 = field16;
+  }
+
+  public String getField17() {
+    return field17;
+  }
+
+  public void setField17(String field17) {
+    this.field17 = field17;
+  }
+
+  public String getField18() {
+    return field18;
+  }
+
+  public void setField18(String field18) {
+    this.field18 = field18;
+  }
+
+  public String getField19() {
+    return field19;
+  }
+
+  public void setField19(String field19) {
+    this.field19 = field19;
+  }
+
+  public String getField20() {
+    return field20;
+  }
+
+  public void setField20(String field20) {
+    this.field20 = field20;
+  }
+
+  public String getField21() {
+    return field21;
+  }
+
+  public void setField21(String field21) {
+    this.field21 = field21;
+  }
+
+  public String getField22() {
+    return field22;
+  }
+
+  public void setField22(String field22) {
+    this.field22 = field22;
+  }
+
+  public String getField23() {
+    return field23;
+  }
+
+  public void setField23(String field23) {
+    this.field23 = field23;
+  }
+
+  public String getField24() {
+    return field24;
+  }
+
+  public void setField24(String field24) {
+    this.field24 = field24;
+  }
+
+  public String getField25() {
+    return field25;
+  }
+
+  public void setField25(String field25) {
+    this.field25 = field25;
+  }
+
+  public String getField26() {
+    return field26;
+  }
+
+  public void setField26(String field26) {
+    this.field26 = field26;
+  }
+
+  public String getField27() {
+    return field27;
+  }
+
+  public void setField27(String field27) {
+    this.field27 = field27;
+  }
+
+  public String getField28() {
+    return field28;
+  }
+
+  public void setField28(String field28) {
+    this.field28 = field28;
+  }
+
+  public String getField29() {
+    return field29;
+  }
+
+  public void setField29(String field29) {
+    this.field29 = field29;
+  }
+
+  public String getField30() {
+    return field30;
+  }
+
+  public void setField30(String field30) {
+    this.field30 = field30;
+  }
+
+  public String getField31() {
+    return field31;
+  }
+
+  public void setField31(String field31) {
+    this.field31 = field31;
+  }
+
+  public String getField32() {
+    return field32;
+  }
+
+  public void setField32(String field32) {
+    this.field32 = field32;
+  }
+
+  public String getField33() {
+    return field33;
+  }
+
+  public void setField33(String field33) {
+    this.field33 = field33;
+  }
+
+  public String getField34() {
+    return field34;
+  }
+
+  public void setField34(String field34) {
+    this.field34 = field34;
+  }
+
+  public String getField35() {
+    return field35;
+  }
+
+  public void setField35(String field35) {
+    this.field35 = field35;
+  }
+
+  public String getField36() {
+    return field36;
+  }
+
+  public void setField36(String field36) {
+    this.field36 = field36;
+  }
+
+  public String getField37() {
+    return field37;
+  }
+
+  public void setField37(String field37) {
+    this.field37 = field37;
+  }
+
+  public String getField38() {
+    return field38;
+  }
+
+  public void setField38(String field38) {
+    this.field38 = field38;
+  }
+
+  public String getField39() {
+    return field39;
+  }
+
+  public void setField39(String field39) {
+    this.field39 = field39;
+  }
+
+  public String getField40() {
+    return field40;
+  }
+
+  public void setField40(String field40) {
+    this.field40 = field40;
+  }
+
+  public String getField41() {
+    return field41;
+  }
+
+  public void setField41(String field41) {
+    this.field41 = field41;
+  }
+
+  public String getField42() {
+    return field42;
+  }
+
+  public void setField42(String field42) {
+    this.field42 = field42;
+  }
+
+  public String getField43() {
+    return field43;
+  }
+
+  public void setField43(String field43) {
+    this.field43 = field43;
+  }
+
+  public String getField44() {
+    return field44;
+  }
+
+  public void setField44(String field44) {
+    this.field44 = field44;
+  }
+
+  public String getField45() {
+    return field45;
+  }
+
+  public void setField45(String field45) {
+    this.field45 = field45;
+  }
+
+  public String getField46() {
+    return field46;
+  }
+
+  public void setField46(String field46) {
+    this.field46 = field46;
+  }
+
+  public String getField47() {
+    return field47;
+  }
+
+  public void setField47(String field47) {
+    this.field47 = field47;
+  }
+
+  public String getField48() {
+    return field48;
+  }
+
+  public void setField48(String field48) {
+    this.field48 = field48;
+  }
+
+  public String getField49() {
+    return field49;
+  }
+
+  public void setField49(String field49) {
+    this.field49 = field49;
+  }
+
+  public String getField50() {
+    return field50;
+  }
+
+  public void setField50(String field50) {
+    this.field50 = field50;
+  }
+
+  public List<GiantFieldDto> getFields1() {
+    return fields1;
+  }
+
+  public void setFields1(List<GiantFieldDto> fields1) {
+    this.fields1 = fields1;
+  }
+
+  public List<GiantFieldDto> getFields2() {
+    return fields2;
+  }
+
+  public void setFields2(List<GiantFieldDto> fields2) {
+    this.fields2 = fields2;
+  }
+
+  public List<GiantFieldDto> getFields3() {
+    return fields3;
+  }
+
+  public void setFields3(List<GiantFieldDto> fields3) {
+    this.fields3 = fields3;
+  }
+
+  public List<GiantFieldDto> getFields4() {
+    return fields4;
+  }
+
+  public void setFields4(List<GiantFieldDto> fields4) {
+    this.fields4 = fields4;
+  }
+
+  public List<GiantFieldDto> getFields5() {
+    return fields5;
+  }
+
+  public void setFields5(List<GiantFieldDto> fields5) {
+    this.fields5 = fields5;
+  }
+
+  public List<GiantFieldDto> getFields6() {
+    return fields6;
+  }
+
+  public void setFields6(List<GiantFieldDto> fields6) {
+    this.fields6 = fields6;
+  }
+
+  public List<GiantFieldDto> getFields7() {
+    return fields7;
+  }
+
+  public void setFields7(List<GiantFieldDto> fields7) {
+    this.fields7 = fields7;
+  }
+
+  public List<GiantFieldDto> getFields8() {
+    return fields8;
+  }
+
+  public void setFields8(List<GiantFieldDto> fields8) {
+    this.fields8 = fields8;
+  }
+
+  public List<GiantFieldDto> getFields9() {
+    return fields9;
+  }
+
+  public void setFields9(List<GiantFieldDto> fields9) {
+    this.fields9 = fields9;
+  }
+
+  public List<GiantFieldDto> getFields10() {
+    return fields10;
+  }
+
+  public void setFields10(List<GiantFieldDto> fields10) {
+    this.fields10 = fields10;
+  }
+
+  public List<GiantFieldDto> getFields11() {
+    return fields11;
+  }
+
+  public void setFields11(List<GiantFieldDto> fields11) {
+    this.fields11 = fields11;
+  }
+
+  public List<GiantFieldDto> getFields12() {
+    return fields12;
+  }
+
+  public void setFields12(List<GiantFieldDto> fields12) {
+    this.fields12 = fields12;
+  }
+
+  public List<GiantFieldDto> getFields13() {
+    return fields13;
+  }
+
+  public void setFields13(List<GiantFieldDto> fields13) {
+    this.fields13 = fields13;
+  }
+
+  public List<GiantFieldDto> getFields14() {
+    return fields14;
+  }
+
+  public void setFields14(List<GiantFieldDto> fields14) {
+    this.fields14 = fields14;
+  }
+
+  public List<GiantFieldDto> getFields15() {
+    return fields15;
+  }
+
+  public void setFields15(List<GiantFieldDto> fields15) {
+    this.fields15 = fields15;
+  }
+
+  public List<GiantFieldDto> getFields16() {
+    return fields16;
+  }
+
+  public void setFields16(List<GiantFieldDto> fields16) {
+    this.fields16 = fields16;
+  }
+
+  public List<GiantFieldDto> getFields17() {
+    return fields17;
+  }
+
+  public void setFields17(List<GiantFieldDto> fields17) {
+    this.fields17 = fields17;
+  }
+
+  public List<GiantFieldDto> getFields18() {
+    return fields18;
+  }
+
+  public void setFields18(List<GiantFieldDto> fields18) {
+    this.fields18 = fields18;
+  }
+
+  public List<GiantFieldDto> getFields19() {
+    return fields19;
+  }
+
+  public void setFields19(List<GiantFieldDto> fields19) {
+    this.fields19 = fields19;
+  }
+}

--- a/benchmarks/src/main/java/org/modelmapper/benchmarks/model/GiantFieldDto.java
+++ b/benchmarks/src/main/java/org/modelmapper/benchmarks/model/GiantFieldDto.java
@@ -1,0 +1,184 @@
+package org.modelmapper.benchmarks.model;
+
+public class GiantFieldDto {
+  private String field1;
+  private String field2;
+  private String field3;
+  private String field4;
+  private String field5;
+  private String field6;
+  private String field7;
+  private String field8;
+  private String field9;
+  private String field10;
+  private String field11;
+  private String field12;
+  private String field13;
+  private String field14;
+  private String field15;
+  private String field16;
+  private String field17;
+  private String field18;
+  private String field19;
+  private String field20;
+
+  public String getField1() {
+    return field1;
+  }
+
+  public void setField1(String field1) {
+    this.field1 = field1;
+  }
+
+  public String getField2() {
+    return field2;
+  }
+
+  public void setField2(String field2) {
+    this.field2 = field2;
+  }
+
+  public String getField3() {
+    return field3;
+  }
+
+  public void setField3(String field3) {
+    this.field3 = field3;
+  }
+
+  public String getField4() {
+    return field4;
+  }
+
+  public void setField4(String field4) {
+    this.field4 = field4;
+  }
+
+  public String getField5() {
+    return field5;
+  }
+
+  public void setField5(String field5) {
+    this.field5 = field5;
+  }
+
+  public String getField6() {
+    return field6;
+  }
+
+  public void setField6(String field6) {
+    this.field6 = field6;
+  }
+
+  public String getField7() {
+    return field7;
+  }
+
+  public void setField7(String field7) {
+    this.field7 = field7;
+  }
+
+  public String getField8() {
+    return field8;
+  }
+
+  public void setField8(String field8) {
+    this.field8 = field8;
+  }
+
+  public String getField9() {
+    return field9;
+  }
+
+  public void setField9(String field9) {
+    this.field9 = field9;
+  }
+
+  public String getField10() {
+    return field10;
+  }
+
+  public void setField10(String field10) {
+    this.field10 = field10;
+  }
+
+  public String getField11() {
+    return field11;
+  }
+
+  public void setField11(String field11) {
+    this.field11 = field11;
+  }
+
+  public String getField12() {
+    return field12;
+  }
+
+  public void setField12(String field12) {
+    this.field12 = field12;
+  }
+
+  public String getField13() {
+    return field13;
+  }
+
+  public void setField13(String field13) {
+    this.field13 = field13;
+  }
+
+  public String getField14() {
+    return field14;
+  }
+
+  public void setField14(String field14) {
+    this.field14 = field14;
+  }
+
+  public String getField15() {
+    return field15;
+  }
+
+  public void setField15(String field15) {
+    this.field15 = field15;
+  }
+
+  public String getField16() {
+    return field16;
+  }
+
+  public void setField16(String field16) {
+    this.field16 = field16;
+  }
+
+  public String getField17() {
+    return field17;
+  }
+
+  public void setField17(String field17) {
+    this.field17 = field17;
+  }
+
+  public String getField18() {
+    return field18;
+  }
+
+  public void setField18(String field18) {
+    this.field18 = field18;
+  }
+
+  public String getField19() {
+    return field19;
+  }
+
+  public void setField19(String field19) {
+    this.field19 = field19;
+  }
+
+  public String getField20() {
+    return field20;
+  }
+
+  public void setField20(String field20) {
+    this.field20 = field20;
+  }
+}

--- a/benchmarks/src/main/java/org/modelmapper/benchmarks/model/GiantFieldEntity.java
+++ b/benchmarks/src/main/java/org/modelmapper/benchmarks/model/GiantFieldEntity.java
@@ -1,0 +1,184 @@
+package org.modelmapper.benchmarks.model;
+
+public class GiantFieldEntity {
+  private String field1;
+  private String field2;
+  private String field3;
+  private String field4;
+  private String field5;
+  private String field6;
+  private String field7;
+  private String field8;
+  private String field9;
+  private String field10;
+  private String field11;
+  private String field12;
+  private String field13;
+  private String field14;
+  private String field15;
+  private String field16;
+  private String field17;
+  private String field18;
+  private String field19;
+  private String field20;
+
+  public String getField1() {
+    return field1;
+  }
+
+  public void setField1(String field1) {
+    this.field1 = field1;
+  }
+
+  public String getField2() {
+    return field2;
+  }
+
+  public void setField2(String field2) {
+    this.field2 = field2;
+  }
+
+  public String getField3() {
+    return field3;
+  }
+
+  public void setField3(String field3) {
+    this.field3 = field3;
+  }
+
+  public String getField4() {
+    return field4;
+  }
+
+  public void setField4(String field4) {
+    this.field4 = field4;
+  }
+
+  public String getField5() {
+    return field5;
+  }
+
+  public void setField5(String field5) {
+    this.field5 = field5;
+  }
+
+  public String getField6() {
+    return field6;
+  }
+
+  public void setField6(String field6) {
+    this.field6 = field6;
+  }
+
+  public String getField7() {
+    return field7;
+  }
+
+  public void setField7(String field7) {
+    this.field7 = field7;
+  }
+
+  public String getField8() {
+    return field8;
+  }
+
+  public void setField8(String field8) {
+    this.field8 = field8;
+  }
+
+  public String getField9() {
+    return field9;
+  }
+
+  public void setField9(String field9) {
+    this.field9 = field9;
+  }
+
+  public String getField10() {
+    return field10;
+  }
+
+  public void setField10(String field10) {
+    this.field10 = field10;
+  }
+
+  public String getField11() {
+    return field11;
+  }
+
+  public void setField11(String field11) {
+    this.field11 = field11;
+  }
+
+  public String getField12() {
+    return field12;
+  }
+
+  public void setField12(String field12) {
+    this.field12 = field12;
+  }
+
+  public String getField13() {
+    return field13;
+  }
+
+  public void setField13(String field13) {
+    this.field13 = field13;
+  }
+
+  public String getField14() {
+    return field14;
+  }
+
+  public void setField14(String field14) {
+    this.field14 = field14;
+  }
+
+  public String getField15() {
+    return field15;
+  }
+
+  public void setField15(String field15) {
+    this.field15 = field15;
+  }
+
+  public String getField16() {
+    return field16;
+  }
+
+  public void setField16(String field16) {
+    this.field16 = field16;
+  }
+
+  public String getField17() {
+    return field17;
+  }
+
+  public void setField17(String field17) {
+    this.field17 = field17;
+  }
+
+  public String getField18() {
+    return field18;
+  }
+
+  public void setField18(String field18) {
+    this.field18 = field18;
+  }
+
+  public String getField19() {
+    return field19;
+  }
+
+  public void setField19(String field19) {
+    this.field19 = field19;
+  }
+
+  public String getField20() {
+    return field20;
+  }
+
+  public void setField20(String field20) {
+    this.field20 = field20;
+  }
+}

--- a/core/src/main/java/org/modelmapper/ModelMapper.java
+++ b/core/src/main/java/org/modelmapper/ModelMapper.java
@@ -562,7 +562,7 @@ public class ModelMapper {
     if (source != null)
       sourceType = Types.<S>deProxy(source.getClass());
     Assert.state(config.typeMapStore.get(sourceType, destinationType, typeMapName) == null,
-        String.format("A TypeMap already exists for %s and %s", sourceType, destinationType));
+        "A TypeMap already exists for %s and %s", sourceType, destinationType);
     return config.typeMapStore.create(source, sourceType, destinationType, typeMapName,
         (InheritingConfiguration) configuration, engine);
   }

--- a/core/src/main/java/org/modelmapper/internal/PropertyInfoImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/PropertyInfoImpl.java
@@ -15,14 +15,12 @@
  */
 package org.modelmapper.internal;
 
-import net.jodah.typetools.TypeResolver;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-
+import net.jodah.typetools.TypeResolver;
 import org.modelmapper.spi.PropertyInfo;
 import org.modelmapper.spi.PropertyType;
 import org.modelmapper.spi.ValueReader;
@@ -255,14 +253,18 @@ abstract class PropertyInfoImpl<M extends Member> implements PropertyInfo {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj)
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
-    if (obj == null || !(obj instanceof PropertyInfo))
+    }
+    if (o == null || getClass() != o.getClass()) {
       return false;
-    PropertyInfoImpl<?> other = (PropertyInfoImpl<?>) obj;
-    return member.getDeclaringClass().equals(other.member.getDeclaringClass())
-        && name.equals(other.getName());
+    }
+    PropertyInfoImpl<?> that = (PropertyInfoImpl<?>) o;
+    if (member != null ? !member.equals(that.member) : that.member != null) {
+      return false;
+    }
+    return name.equals(that.name);
   }
 
   public Class<?> getInitialType() {

--- a/core/src/main/java/org/modelmapper/internal/TypeMapStore.java
+++ b/core/src/main/java/org/modelmapper/internal/TypeMapStore.java
@@ -202,7 +202,9 @@ public final class TypeMapStore {
   }
 
   private <S> boolean isAnonymousEnumSubclass(Class<S> sourceType) {
-    return sourceType.isAnonymousClass() && sourceType.getSuperclass().isEnum();
+    return sourceType.getSuperclass() != null
+        && sourceType.getSuperclass().isEnum()
+        && sourceType.isAnonymousClass();
   }
 
 }

--- a/core/src/main/java/org/modelmapper/internal/TypeResolvingList.java
+++ b/core/src/main/java/org/modelmapper/internal/TypeResolvingList.java
@@ -122,8 +122,9 @@ public class TypeResolvingList<T> extends AbstractList<T> {
   private boolean addElement(T element) {
     Assert.notNull(element, "element");
     Class<?> typeArgument = TypeResolver.resolveRawArgument(valueAccessorType, element.getClass());
-    Assert.notNull(typeArgument, "Must declare source type argument <T> for the "
-        + valueAccessorType.getSimpleName());
+    if (typeArgument == null) {
+      throw new IllegalArgumentException("Must declare source type argument <T> for the " + valueAccessorType.getSimpleName());
+    }
     elements.put(element, typeArgument);
     return true;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <module>core</module>
     <module>extensions</module>
     <module>examples</module>
+    <module>benchmarks</module>
   </modules>
 
   <dependencies>


### PR DESCRIPTION
Resolved: #618 

Before

```
Benchmark                             Mode  Cnt    Score    Error  Units
GiantModelBenchmark.measure          thrpt    5  170.129 ± 18.995  ops/s
GiantModelBenchmark.measureSubclass  thrpt    5  158.574 ± 24.168  ops/s
```

After

```
Benchmark                             Mode  Cnt    Score     Error  Units
GiantModelBenchmark.measure          thrpt    5  856.024 ±  25.241  ops/s
GiantModelBenchmark.measureSubclass  thrpt    5  897.057 ± 117.059  ops/s
```

