### PR TITLE
add interceptor for the mapping engine resolveSourceValue method retu…

### DIFF
--- a/core/src/main/java/org/modelmapper/ResolveSourceValueInterceptor.java
+++ b/core/src/main/java/org/modelmapper/ResolveSourceValueInterceptor.java
@@ -1,0 +1,7 @@
+package org.modelmapper;
+
+public interface ResolveSourceValueInterceptor<S> {
+
+    S use(Object object);
+
+}

--- a/core/src/main/java/org/modelmapper/config/Configuration.java
+++ b/core/src/main/java/org/modelmapper/config/Configuration.java
@@ -18,6 +18,7 @@ package org.modelmapper.config;
 import org.modelmapper.Condition;
 import org.modelmapper.PropertyMap;
 import org.modelmapper.Provider;
+import org.modelmapper.ResolveSourceValueInterceptor;
 import org.modelmapper.spi.*;
 import org.modelmapper.spi.ConditionalConverter.MatchResult;
 
@@ -133,6 +134,14 @@ public interface Configuration {
    * @see #setPropertyCondition(Condition)
    */
   Condition<?, ?> getPropertyCondition();
+
+
+  /**
+   * Return the Interceptor for the mapping engine resolveSourceValue mapping
+   * {@code null} if no interceptor has been configured.
+   * @see #setResolveSourceValueInterceptor(ResolveSourceValueInterceptor)
+   */
+  ResolveSourceValueInterceptor<?> getResolveSourceValueInterceptor();
 
   /**
    * Returns the Provider used for provisioning destination object instances, else {@code null} if
@@ -451,6 +460,12 @@ public interface Configuration {
    * @throws IllegalArgumentException if {@code condition} is null
    */
   Configuration setPropertyCondition(Condition<?, ?> condition);
+
+
+  /**
+   * Sets  interceptor for the mapping engine's resolveSourceValue methods.
+   */
+  Configuration setResolveSourceValueInterceptor(ResolveSourceValueInterceptor<?> interceptor);
 
   /**
    * Sets the {@code provider} to use for providing destination object instances.

--- a/core/src/main/java/org/modelmapper/internal/InheritingConfiguration.java
+++ b/core/src/main/java/org/modelmapper/internal/InheritingConfiguration.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.modelmapper.Condition;
 import org.modelmapper.Provider;
+import org.modelmapper.ResolveSourceValueInterceptor;
 import org.modelmapper.config.Configuration;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.convention.NameTokenizers;
@@ -58,6 +59,7 @@ public class InheritingConfiguration implements Configuration {
   private AccessLevel methodAccessLevel;
   private Provider<?> provider;
   private Condition<?, ?> propertyCondition;
+  private ResolveSourceValueInterceptor<?> resolveSourceValueInterceptor;
   private NameTokenizer sourceNameTokenizer;
   private NameTransformer sourceNameTransformer;
   private NamingConvention sourceNamingConvention;
@@ -229,6 +231,15 @@ public class InheritingConfiguration implements Configuration {
           ? parent.getPropertyCondition()
           : propertyCondition;
     return propertyCondition;
+  }
+
+  @Override
+  public ResolveSourceValueInterceptor<?> getResolveSourceValueInterceptor() {
+    if (parent != null)
+      return resolveSourceValueInterceptor == null
+              ? parent.getResolveSourceValueInterceptor()
+              : resolveSourceValueInterceptor;
+    return resolveSourceValueInterceptor;
   }
 
   @Override
@@ -440,6 +451,12 @@ public class InheritingConfiguration implements Configuration {
   @Override
   public Configuration setPropertyCondition(Condition<?, ?> condition) {
     propertyCondition = Assert.notNull(condition);
+    return this;
+  }
+
+  @Override
+  public Configuration setResolveSourceValueInterceptor(ResolveSourceValueInterceptor<?> condition) {
+    resolveSourceValueInterceptor = Assert.notNull(condition);
     return this;
   }
 

--- a/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
@@ -21,12 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.modelmapper.Condition;
-import org.modelmapper.ConfigurationException;
-import org.modelmapper.Converter;
-import org.modelmapper.Provider;
-import org.modelmapper.TypeMap;
-import org.modelmapper.TypeToken;
+import org.modelmapper.*;
 import org.modelmapper.internal.converter.ConverterStore;
 import org.modelmapper.internal.util.Iterables;
 import org.modelmapper.internal.util.Objects;
@@ -196,6 +191,13 @@ public class MappingEngineImpl implements MappingEngine {
         destPathBuilder.append(accessor.getName()).append('.');
         source = accessor.getValue(source);
         context.addParentSource(destPathBuilder.toString(), source);
+
+        ResolveSourceValueInterceptor<?> interceptor = configuration.getResolveSourceValueInterceptor();
+
+        if (interceptor != null) {
+          source = interceptor.use(source);
+        }
+
         if (source == null)
           return null;
         if (!Iterables.isIterable(source.getClass())) {


### PR DESCRIPTION
Probably when hibernate session is used, it creates empty hibernate proxy instance for lazy loaded fields. Therefore, it causes lazy load exception or n+1 select problem when using model mapper deep copying.

Example usage for intercepter:

```java
mapper.getConfiguration().setResolveSourceValueInterceptor(source -> {
    if (emFactory.getPersistenceUnitUtil().isLoaded(source)) {
            return source;
    }
    return null; // return null when hibernate field is not fetch from database (lazy loading)
});
```


The problem solution has been provided based on the issue here [https://github.com/modelmapper/modelmapper/issues/97](https://github.com/modelmapper/modelmapper/issues/97). 