### PR TITLE
add UuidConverter to support UUID

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/converter/ConverterStore.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/ConverterStore.java
@@ -30,7 +30,7 @@ public final class ConverterStore {
           new FromOptionalConverter(),new OptionalConverter(), new ToOptionalConverter(),
           new AssignableConverter(), new StringConverter(), new EnumConverter(), new NumberConverter(),
           new BooleanConverter(), new CharacterConverter(), new DateConverter(),
-          new CalendarConverter(),
+          new CalendarConverter(), new UuidConverter(),
   };
 
   private final List<ConditionalConverter<?, ?>> converters;

--- a/core/src/main/java/org/modelmapper/internal/converter/UuidConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/UuidConverter.java
@@ -1,0 +1,26 @@
+package org.modelmapper.internal.converter;
+
+import org.modelmapper.spi.ConditionalConverter;
+import org.modelmapper.spi.MappingContext;
+
+import java.util.UUID;
+
+class UuidConverter implements ConditionalConverter<Object, UUID>{
+    public UUID convert(MappingContext<Object, UUID> context) {
+        Object source = context.getSource();
+        if (source == null)
+            return null;
+
+        Class<?> sourceType = context.getSourceType();
+
+        String string = sourceType.isArray() && sourceType.getComponentType() == Character.TYPE
+                || sourceType.getComponentType() == Character.class ? String.valueOf((char[]) source)
+                : source.toString();
+        return UUID.fromString(string);
+    }
+
+    public MatchResult match(Class<?> sourceType, Class<?> destinationType) {
+        return destinationType == UUID.class ? sourceType == UUID.class ? MatchResult.FULL
+                : MatchResult.PARTIAL : MatchResult.NONE;
+    }
+}


### PR DESCRIPTION
## Related issues
Fixes #660 
## Describe the PR
There was an error before because of the UUID.
Failed to instantiate instance of destination java.util.UUID. Ensure that java.util.UUID has a non-private no-argument constructor.
This PR fixes the errotrby adding an UuidConventer to support UUID.