### PR TITLE
Fix error message while skip conflict

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/ReferenceMapExpressionImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/ReferenceMapExpressionImpl.java
@@ -96,7 +96,7 @@ class ReferenceMapExpressionImpl<S, D> implements ReferenceMapExpression<S, D> {
     options.skipType = 1;
     visitSource(sourceGetter);
     visitDestination(destinationSetter);
-    typeMap.addMapping(collector.collect());
+    skipMapping(collector.collect());
     collector.reset();
   }
 

--- a/core/src/test/java/org/modelmapper/bugs/GH578.java
+++ b/core/src/test/java/org/modelmapper/bugs/GH578.java
@@ -1,0 +1,69 @@
+package org.modelmapper.bugs;
+
+import lombok.Data;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.ConfigurationException;
+import org.modelmapper.ModelMapper;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+@Test
+public class GH578 extends AbstractTest {
+
+    enum CLASSIFIER{
+        AAA,
+        BBB;
+    }
+
+    @Data
+    class TypeA {
+        TypeABox box;
+    }
+
+    @Data
+    class TypeABox {
+        CLASSIFIER param;
+
+    }
+
+    @Data
+    class TypeB {
+        TypeBBox box;
+    }
+
+    @Data
+    class TypeBBox {
+        CLASSIFIER param;
+    }
+
+    public void testBoxMapping() {
+
+        TypeA typeA = new TypeA();
+        TypeABox typeABox = new TypeABox();
+
+        typeABox.setParam(CLASSIFIER.AAA);
+        typeA.setBox(typeABox);
+
+        TypeB typeB = new TypeB();
+        TypeBBox typeBBox = new TypeBBox();
+
+        typeBBox.setParam(CLASSIFIER.BBB);
+        typeB.setBox(typeBBox);
+        ModelMapper modelMapper = new ModelMapper();
+        try {
+            modelMapper.createTypeMap(TypeA.class, TypeB.class)
+                    .addMappings(mapper -> mapper.skip(TypeA::getBox,TypeB::setBox));
+            fail();
+        }catch (ConfigurationException e) {
+            assertEquals(e.getErrorMessages().size(), 1);
+            assertEquals(e.getErrorMessages().iterator().next().getMessage(),
+                    "Not able to skip box., because there are already nested properties are mapped: [box.param.]. "
+                            + "Do you skip the property after the implicit mappings mapped? "
+                            + "We recommended you to create an empty type map, and followed by addMappings and implicitMappings calls" );
+        }
+        modelMapper.map(typeA, typeB);
+    }
+}

--- a/core/src/test/java/org/modelmapper/bugs/GH578.java
+++ b/core/src/test/java/org/modelmapper/bugs/GH578.java
@@ -1,7 +1,5 @@
 package org.modelmapper.bugs;
 
-import lombok.Data;
-
 import org.modelmapper.AbstractTest;
 import org.modelmapper.ConfigurationException;
 import org.modelmapper.ModelMapper;
@@ -18,25 +16,52 @@ public class GH578 extends AbstractTest {
         BBB;
     }
 
-    @Data
     class TypeA {
         TypeABox box;
+
+        public void setBox(TypeABox box) {
+            this.box = box;
+        }
+
+        public TypeABox getBox() {
+            return box;
+        }
     }
 
-    @Data
     class TypeABox {
         CLASSIFIER param;
 
+        public CLASSIFIER getParam() {
+            return param;
+        }
+
+        public void setParam(CLASSIFIER param) {
+            this.param = param;
+        }
     }
 
-    @Data
     class TypeB {
         TypeBBox box;
+
+        public TypeBBox getBox() {
+            return box;
+        }
+
+        public void setBox(TypeBBox box) {
+            this.box = box;
+        }
     }
 
-    @Data
     class TypeBBox {
         CLASSIFIER param;
+
+        public CLASSIFIER getParam() {
+            return param;
+        }
+
+        public void setParam(CLASSIFIER param) {
+            this.param = param;
+        }
     }
 
     public void testBoxMapping() {


### PR DESCRIPTION
## Related issues
Fixes #578 </br>
This issue is that skipping of nested value is subjected to mapping definition order. Actually, it is not related to the definition order but the skip() method and nested value.
## Describe the PR
A few days ago, #668 add error message about the skip conflict. However, the skip() method has method overloading, and it only modifies one method of them. And this pr modify another skip() method in ` ReferenceMapExpressionImpl.java`.