### PR TITLE
fix issue 164

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/ImplicitMappingBuilder.java
+++ b/core/src/main/java/org/modelmapper/internal/ImplicitMappingBuilder.java
@@ -95,7 +95,9 @@ class ImplicitMappingBuilder<S, D> {
    * {@code sourceTypeInfo}'s accessor hierarchy.
    */
   private void matchDestination(TypeInfo<?> destinationTypeInfo) {
-    destinationTypes.add(destinationTypeInfo.getType());
+    if (!(propertyNameInfo.getDestinationProperties().size() == 0)){
+      destinationTypes.add(destinationTypeInfo.getType());
+    }
 
     for (Map.Entry<String, Mutator> entry : destinationTypeInfo.getMutators().entrySet()) {
       propertyNameInfo.pushDestination(entry.getKey(), entry.getValue());

--- a/core/src/test/java/org/modelmapper/internal/CyclicMappingTest.java
+++ b/core/src/test/java/org/modelmapper/internal/CyclicMappingTest.java
@@ -1,0 +1,41 @@
+package org.modelmapper.internal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+import java.util.UUID;
+import lombok.Data;
+
+public class CyclicMappingTest {
+    ModelMapper modelMapper = new ModelMapper();
+    @Data
+    private static class Action {
+        UUID id;
+        Action previous;
+    }
+
+    @Data
+    private static class ActionDTO {
+        UUID id;
+        UUID previousId;
+    }
+
+    @Test
+    public void testPreviousLink() {
+
+        ActionDTO dto = new ActionDTO();
+        dto.setPreviousId(UUID.randomUUID());
+        dto.setId(UUID.randomUUID());
+
+        Action model = modelMapper.map(dto, Action.class);
+
+        Assertions.assertInstanceOf(Action.class, model);
+
+        Assertions.assertEquals(model.getId(), dto.getId());
+
+        Assertions.assertNotNull(model.getPrevious()); // fails here when strict
+        Assertions.assertInstanceOf(Action.class, model.getPrevious());
+
+        Assertions.assertEquals(model.getPrevious().getId(), dto.getPreviousId()); // fails here with normal matching
+    }
+}


### PR DESCRIPTION
For cyclic situation, it is designed to have deep map in first layer and shallow map for the layer nested, so it should do the cyclic map for the first `Action`, but somehow, for the destination class is `Action`, it is considered to have mapped the `Action` once, so there is the bug, and I fix it by not adding the destination class when at first, then it went well. Issue #164 
