### PR TITLE
fix issue 147

### DIFF
--- a/core/src/test/java/org/modelmapper/MapTooMuchTest.java
+++ b/core/src/test/java/org/modelmapper/MapTooMuchTest.java
@@ -1,0 +1,56 @@
+package org.modelmapper;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.modelmapper.convention.MatchingStrategies;
+
+public class MapTooMuchTest {
+
+    @Data
+    private static class User {
+        String login;
+        int businessId;
+        int id = 3;
+    }
+
+    @Data
+    private static class NewUser {
+        String login;
+        int businessId;
+    }
+
+    @Test
+    public void testUserId1() {
+        NewUser newUser = new NewUser();
+        newUser.setLogin("abcdefg");
+        newUser.setBusinessId(1);
+
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STANDARD);
+        User user = mapper.map(newUser, User.class);
+
+        Assert.assertEquals(user.getId(), 3);
+        Assert.assertEquals(user.getLogin(), "abcdefg");
+        Assert.assertEquals(user.getBusinessId(), 1);
+    }
+
+    @Test
+    public void testUserId2() {
+        NewUser newUser = new NewUser();
+        newUser.setLogin("abcdefg");
+        newUser.setBusinessId(1);
+
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        User user = mapper.map(newUser, User.class);
+
+        Assert.assertEquals(user.getId(), 3);
+        Assert.assertEquals(user.getLogin(), "abcdefg");
+        Assert.assertEquals(user.getBusinessId(), 1);
+    }
+
+}
+
+


### PR DESCRIPTION
The PR adds a test file MapTooMuchTest.java, trying to fix [issue 147](https://github.com/modelmapper/modelmapper/issues/147).

Actually, if we don't want to map too much, we can use strict matching strategy. With it, all destination property name tokens must be matched and all source property names must have all tokens matched.