### PR TITLE
Issue 685: No session found exception when mapping Hibernate Objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ release.properties
 _site/
 user-manual/
 *.iml
+.idea

--- a/core/src/main/java/org/modelmapper/internal/converter/NonMergingCollectionConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/NonMergingCollectionConverter.java
@@ -41,23 +41,17 @@ public class NonMergingCollectionConverter implements ConditionalConverter<Objec
     if (source == null)
       return null;
 
-    Collection<Object> originalDestination = context.getDestination();
     Collection<Object> destination = MappingContextHelper.createCollection(context);
     Class<?> elementType = MappingContextHelper.resolveDestinationGenericType(context);
 
-    int index = 0;
-    for (Iterator<Object> iterator = Iterables.iterator(source); iterator.hasNext(); index++) {
+    for (Iterator<Object> iterator = Iterables.iterator(source); iterator.hasNext();) {
       Object sourceElement = iterator.next();
-      Object element = null;
-      if (originalDestination != null)
-        element = Iterables.getElement(originalDestination, index);
+      Object destinationElement = null;
       if (sourceElement != null) {
-        MappingContext<?, ?> elementContext = element == null
-            ? context.create(sourceElement, elementType)
-            : context.create(sourceElement, element);
-        element = context.getMappingEngine().map(elementContext);
+        MappingContext<?, ?> elementContext = context.create(sourceElement, elementType);
+        destinationElement = context.getMappingEngine().map(elementContext);
       }
-      destination.add(element);
+      destination.add(destinationElement);
     }
 
     return destination;

--- a/core/src/test/java/org/modelmapper/internal/converter/NonMergingCollectionConverterTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/NonMergingCollectionConverterTest.java
@@ -1,5 +1,6 @@
 package org.modelmapper.internal.converter;
 
+import org.hibernate.collection.internal.PersistentBag;
 import org.modelmapper.spi.ConditionalConverter.MatchResult;
 import org.testng.annotations.Test;
 
@@ -160,5 +161,11 @@ public class NonMergingCollectionConverterTest extends AbstractConverterTest {
 
     // Negative
     assertEquals(converter.match(Map.class, ArrayList.class), MatchResult.NONE);
+  }
+
+  public void itShouldNotThrowAnExceptionIfDestinationIsHibernateProxyObjectAndThereIsNoSession() {
+      List<Integer> sourceList = Arrays.asList(1, 2, 3);
+      Class<?> destinationType = List.class;
+      assertEquals(convert(sourceList, new PersistentBag(), destinationType), sourceList);
   }
 }


### PR DESCRIPTION
- Ensured that only the type of the destination object is used during a non merging collection converter
- Do not try to inspect the contents of a collection

Fixes #685