### PR TITLE
Fix flaky tests caused by nondeterministic of HashSets and HashMaps

### DIFF
--- a/core/src/test/java/org/modelmapper/internal/TypeInfoImplTest.java
+++ b/core/src/test/java/org/modelmapper/internal/TypeInfoImplTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Collections;
 
 import org.modelmapper.config.Configuration.AccessLevel;
 import org.testng.annotations.BeforeClass;
@@ -42,16 +43,25 @@ public class TypeInfoImplTest {
    */
   public void shouldProduceAccessors() {
     List<Mutator> mutators = new ArrayList<Mutator>(personInfo.getMutators().values());
+    List<String> orderMutators = new ArrayList<String>();
+    orderMutators.add(mutators.get(0).getMember().getName()); 
+    orderMutators.add(mutators.get(1).getMember().getName());                           
+    Collections.sort(orderMutators);                    
     assertEquals(mutators.size(), 2);
-    assertEquals(mutators.get(0).getMember().getName(), "setFirstName");
-    assertEquals(mutators.get(1).getMember().getName(), "age");
+    assertEquals(orderMutators.get(0), "age");
+    assertEquals(orderMutators.get(1), "setFirstName");
   }
 
   public void shouldProduceMutators() {
     List<Accessor> accessors = new ArrayList<Accessor>(personInfo.getAccessors().values());
+    List<String> orderAccessors = new ArrayList<String>();
+    for (int i = 0; i < accessors.size(); i++) {
+      orderAccessors.add(accessors.get(i).getMember().getName()); 
+    }                      
+    Collections.sort(orderAccessors);
     assertEquals(accessors.size(), 3);
-    assertEquals(accessors.get(0).getMember().getName(), "firstName");
-    assertEquals(accessors.get(1).getMember().getName(), "age");
-    assertEquals(accessors.get(2).getMember().getName(), "getLastName");
+    assertEquals(orderAccessors.get(0), "age");
+    assertEquals(orderAccessors.get(1), "firstName");
+    assertEquals(orderAccessors.get(2), "getLastName");
   }
 }

--- a/core/src/test/java/org/modelmapper/internal/converter/ArrayConverterTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/ArrayConverterTest.java
@@ -4,7 +4,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -51,7 +51,7 @@ public class ArrayConverterTest extends AbstractConverterTest {
   }
 
   public void shouldConvertFromSet() {
-    Set<Integer> source = new HashSet<Integer>(Arrays.asList(3, 4, 5));
+    Set<Integer> source = new LinkedHashSet<Integer>(Arrays.asList(3, 4, 5));
     String[] dest = (String[]) convert(source, String[].class);
     assertEquals(Arrays.asList(dest), Arrays.asList("3", "4", "5"));
   }


### PR DESCRIPTION
The tests below were found flaky because of the ordering of `HashSets` and `HashMaps`. The orders of elements in the HashSets and HashMaps are not the same every time the test being called. In this case, `HashSet` is changed into `LinkedHashSet`, and the unordered results from `HashMap` are sorted for comparing. This code change is trying to fix the [flaky tests](https://docs.gitlab.com/ee/development/testing_guide/flaky_tests.html) mentioned above, because they sometimes fail (as the picture showed) and sometimes pass when comparing the strings. The failure could be reproduced by the commands above by using the tool of [NonDex](https://github.com/TestingResearchIllinois/NonDex). The code change is to make sure the tests will always pass in this case.

- `org.modelmapper.internal.converter.ArrayConverterTest.shouldConvertFromSet`
- `org.modelmapper.internal.TypeInfoImplTest.shouldProduceMutators`
- `org.modelmapper.internal.TypeInfoImplTest.shouldProduceAccessors`

The test failures could be reproduced by

1. `mvn install -pl . -am -DskipTests`
2.  run tests with NonDex 
    `mvn -pl core edu.illinois:nondex-maven-plugin:1.1.2:nondex 
     -Dtest=org.modelmapper.internal.TypeInfoImplTest#shouldProduceAccessors`
<img width="783" alt="1" src="https://user-images.githubusercontent.com/61256379/196843098-2f46e44f-06e5-444a-8527-28834641047d.png">