### PR TITLE
Compatibility with Java 19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <cglib.version>3.3.0</cglib.version>
-    <asm.version>9.2</asm.version>
+    <asm.version>9.4</asm.version>
     <objenesis.version>3.2</objenesis.version>
     <typetools.version>0.6.3</typetools.version>
     <bytebuddy.version>1.12.3</bytebuddy.version>


### PR DESCRIPTION
## Problem

Our project is using Java 18 and we have tried to upgrade it to Java 19.
The code compiled properly, but the modules using the ModelMapper dependency began to fail in runtime with the following message:

    Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 63 at org.modelmapper.internal.asm.ClassReader.<init>(ClassReader.java:199)

## Solution

The `org.modelmapper.internal.asm.ClassReader` class mentioned above comes from the `asm-tree` library (`org.objectweb.asm` is shaded by the `maven-shade-plugin` configured in ModelMapper).

The update of the `asm-tree` library to the latest version `9.4` seems to solve the issue: it compiles properly and there are no more runtime failures.
