### PR TITLE
Add support for Permazen proxies

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/util/Types.java
+++ b/core/src/main/java/org/modelmapper/internal/util/Types.java
@@ -80,6 +80,8 @@ public final class Types {
       return true;
     if (type.getName().contains("$MockitoMock$"))
       return true;
+    if (type.getName().contains("$$Permazen"))
+      return true;
     if (Proxy.isProxyClass(type))
       return true;
     return isProxiedByJavassist(type);


### PR DESCRIPTION
I have a project using [Permazen](https://github.com/permazen/permazen) ORM. _ModelMapper_ does not recognize permazen's proxies. It's just the matter of two strings addition in `Types` utility class to support these. I realize that _Permazen ORM_ is rarely used, but appreciate if you'll accept this small PR.