### PR TITLE
fix(sec): upgrade org.testng:testng to 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <h2.version>2.0.206</h2.version>
     <hibernate.version>5.6.3.Final</hibernate.version>
     <slf4j.version>1.5.8</slf4j.version>
-    <testng.version>7.5</testng.version>
+    <testng.version>7.7.0</testng.version>
     <mockito.version>4.2.0</mockito.version>
     <dozer.version>5.5.1</dozer.version>
     <orika.version>1.5.4</orika.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.testng:testng 7.5
- [CVE-2022-4065](https://www.oscs1024.com/hd/CVE-2022-4065)


### What did I do？
Upgrade org.testng:testng from 7.5 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS