### PR TITLE
New StrictFlatNestedMatchingStrategy implementation

### DIFF
--- a/core/src/main/java/org/modelmapper/convention/MatchingStrategies.java
+++ b/core/src/main/java/org/modelmapper/convention/MatchingStrategies.java
@@ -65,4 +65,19 @@ public class MatchingStrategies {
    * </ul>
    */
   public static final MatchingStrategy STRICT = new StrictMatchingStrategy();
+
+  /**
+   * A matching strategy that allows for source properties to be strictly matched to destination
+   * properties, while respecting flat to nested or nested to flat structure.
+   * This strategy allows for complete matching accuracy, ensuring that no mismatches or
+   * ambiguity occurs. It requires that property name tokens on the source and destination side
+   * match each other precisely, while respecting the flat to nested or nested to flat structure. The following rules apply:
+   *
+   * <ul>
+   * <li>Tokens are matched in <i>strict flat nested</i> order</li>
+   * <li>All destination property name tokens must be matched</li>
+   * <li>All source property names must have all tokens matched</li>
+   * </ul>
+   */
+  public static final MatchingStrategy STRICT_FLAT_NESTED = new StrictFlatNestedMatchingStrategy();
 }

--- a/core/src/main/java/org/modelmapper/convention/StrictFlatNestedMatchingStrategy.java
+++ b/core/src/main/java/org/modelmapper/convention/StrictFlatNestedMatchingStrategy.java
@@ -1,0 +1,118 @@
+package org.modelmapper.convention;
+
+import org.modelmapper.spi.MatchingStrategy;
+import org.modelmapper.spi.PropertyNameInfo;
+import org.modelmapper.spi.Tokens;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * See {@link MatchingStrategies#STRICT_FLAT_NESTED}.
+ *
+ * @author Dimitrije Mitić
+ */
+public class StrictFlatNestedMatchingStrategy implements MatchingStrategy {
+
+    @Override
+    public boolean matches(PropertyNameInfo propertyNameInfo) {
+        List<Tokens> sourceTokens = propertyNameInfo.getSourcePropertyTokens();
+        List<Tokens> destinationTokens = propertyNameInfo.getDestinationPropertyTokens();
+
+        if (!Objects.equals(getFirstToken(sourceTokens), getFirstToken(destinationTokens))) {
+            return false;
+        }
+
+        if (!getLastToken(sourceTokens).equals(getLastToken(destinationTokens))) {
+            return false;
+        }
+
+        List<String> indexedSourceTokens = new ArrayList<>();
+        List<String> indexedDestinationTokens = new ArrayList<>();
+
+        int maxFirstLevelTokenSize = Math.max(sourceTokens.size(), destinationTokens.size());
+
+        for (int firstLevelIdx = 0; firstLevelIdx < maxFirstLevelTokenSize; firstLevelIdx++) {
+            Tokens sourceNestedTokens = getToken(sourceTokens, firstLevelIdx);
+            Tokens destinationNestedTokens = getToken(destinationTokens, firstLevelIdx);
+
+            int sourceNestedTokensSize = sourceNestedTokens.size();
+            int destinationNestedTokensSize = destinationNestedTokens.size();
+
+            int maxSizeNestedTokens = Math.max(sourceNestedTokensSize, destinationNestedTokensSize);
+
+            for (int nestedIdx = 0; nestedIdx < maxSizeNestedTokens; nestedIdx++) {
+                if(nestedIdx < sourceNestedTokensSize &&
+                    (!areTokensMatchingAtIndexAndAdd(
+                        indexedSourceTokens,
+                        indexedDestinationTokens,
+                        sourceNestedTokens.token(nestedIdx))
+                    )
+                ) {
+                        return false;
+                }
+
+                if (nestedIdx < destinationNestedTokensSize &&
+                    (!areTokensMatchingAtIndexAndAdd(
+                        indexedDestinationTokens,
+                        indexedSourceTokens,
+                        destinationNestedTokens.token(nestedIdx))
+                    )
+                ) {
+                        return false;
+
+                }
+            }
+        }
+
+        return indexedSourceTokens.size() == indexedDestinationTokens.size();
+    }
+
+    private boolean areTokensMatchingAtIndexAndAdd(List<String> tokensToAddTo,
+                                                   List<String> tokensToCompareTo,
+                                                   String value) {
+        tokensToAddTo.add(value.toLowerCase());
+        int index = tokensToAddTo.size() - 1;
+        if (index < tokensToCompareTo.size()) {
+            return tokensToAddTo.get(index).equals(tokensToCompareTo.get(index));
+        }
+        return true;
+    }
+
+    private String getFirstToken(List<Tokens> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            return null;
+        }
+
+        if (tokens.get(0).size() == 0) {
+            return null;
+        }
+
+        return tokens.get(0).token(0).toLowerCase();
+    }
+
+    private String getLastToken(List<Tokens> tokens) {
+        int tokensSize = tokens.size();
+        Tokens token = tokens.get(tokensSize - 1);
+        return token.token(token.size() - 1).toLowerCase();
+    }
+
+    private Tokens getToken(List<Tokens> tokens, int index) {
+        try {
+            return tokens.get(index);
+        } catch (IndexOutOfBoundsException ex) {
+            return Tokens.of();
+        }
+    }
+
+    @Override
+    public boolean isExact() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "StrictFlatNested";
+    }
+}

--- a/core/src/test/java/org/modelmapper/convention/StrictFlatNestedMatchingStrategyTest.java
+++ b/core/src/test/java/org/modelmapper/convention/StrictFlatNestedMatchingStrategyTest.java
@@ -1,0 +1,208 @@
+package org.modelmapper.convention;
+
+import org.modelmapper.internal.MatchingStrategyTestSupport;
+import org.modelmapper.spi.MatchingStrategy;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the {@link StrictFlatNestedMatchingStrategy} against various source and destination hierarchy
+ * scenarios.
+ * @author Dimitrije Mitić
+ */
+@Test
+public class StrictFlatNestedMatchingStrategyTest extends MatchingStrategyTestSupport {
+  static class Address {
+  }
+
+  static class Artist {
+  }
+
+  static class Customer {
+  }
+
+  static class Name {
+  }
+
+  public StrictFlatNestedMatchingStrategyTest() {
+    super(new StrictFlatNestedMatchingStrategy());
+  }
+
+  protected StrictFlatNestedMatchingStrategyTest(MatchingStrategy matchingStrategy) {
+    super(matchingStrategy);
+  }
+
+  /**
+   * <pre>
+   * Address home -> addressHome
+   * </pre>
+   */
+  public void shouldNotMatchClass() {
+    match(Address.class, "home").to("addressHome").assertNoMatch();
+  }
+
+  /**
+   * <pre>
+   * Address/Integer id -> addressId
+   * </pre>
+   */
+  public void shouldNotMatchDeclaringClass() {
+    match(Address.class, Integer.TYPE, "id").to("addressId").assertNoMatch();
+  }
+
+  /**
+   * <pre>
+   * String name -> name
+   * Artist artist/String name -> artist/name
+   * </pre>
+   */
+  public void shouldMatchEqualHierarchies() {
+    match(String.class, "name").to("name").assertMatch();
+    match(Artist.class, "artist").$(String.class, "name").to("artist", "name").assertMatch();
+  }
+
+  /**
+   * <pre>
+   * String artistName -> artist/name
+   * String customerAddressStreet -> customer/address/street
+   * Address customerAddress/String street -> customer/address/street
+   * </pre>
+   */
+  public void shouldMatchGreaterDestinationHierarchy() {
+    match(String.class, "artistName").to("artist", "name").assertMatch();
+    match(String.class, "customerAddressStreet").to("customer", "address", "street").assertMatch();
+    match(Address.class, "customerAddress").$(String.class, "street")
+        .to("customer", "address", "street")
+        .assertMatch();
+  }
+
+  /**
+   * <pre>
+   * Artist artist/String name -> artistName
+   * Address homeAddress/String street -> homeStreet
+   * Customer customer/Address address/String street -> customerAddressStreet
+   * Customer customer/Address address/String street -> customerAddress/street
+   * </pre>
+   */
+  public void shouldMatchGreaterSourceHierarchy() {
+    match(Artist.class, "artist").$(String.class, "name").to("artistName").assertMatch();
+    match(Address.class, "home").$(String.class, "street").to("homeStreet").assertMatch();
+    match(Customer.class, "customer").$(Address.class, "address")
+        .$(String.class, "street")
+        .to("customerAddressStreet")
+        .assertMatch();
+    match(Customer.class, "customer").$(Address.class, "address")
+        .$(String.class, "street")
+        .to("customerAddress", "street")
+        .assertMatch();
+  }
+
+  /**
+   * <pre>
+   * String addressStreet -> streetAddress;
+   * Address address/Street street -> streetAddress
+   * Customer customer/Name name/String first -> customerFirstName
+   * Customer customer/Name name/String first -> customer/firstName
+   * </pre>
+   */
+  public void shouldNotMatchInverted() {
+    match(String.class, "addressStreet").to("streetAddress").assertNoMatch();
+    match(Address.class, "address").$(String.class, "street").to("streetAddress").assertNoMatch();
+    match(Customer.class, "customer").$(Name.class, "name")
+        .$(String.class, "first")
+        .to("customerFirstName")
+        .assertNoMatch();
+    match(Customer.class, "customer").$(Name.class, "name")
+        .$(String.class, "first")
+        .to("customer", "firstName")
+        .assertNoMatch();
+  }
+
+  /**
+   * <pre>
+   * Address home -> homeAddress
+   * Address home/String street -> homeAddressStreet
+   * Address home/String street -> homeStreetAddress
+   * Address home/String street -> homeAddress/street
+   * </pre>
+   */
+  public void shouldNotMatchInvertedClass() {
+    match(Address.class, "home").$(String.class, "street").to("homeAddressStreet").assertNoMatch();
+    match(Address.class, "home").$(String.class, "street").to("homeStreetAddress").assertNoMatch();
+    match(Address.class, "home").$(String.class, "street")
+        .to("homeAddress", "street")
+        .assertNoMatch();
+  }
+
+  /**
+   * <pre>
+   * Address/String home -> homeAddress
+   * Address/String home -> home/address
+   * </pre>
+   */
+  public void shouldNotMatchInvertedDeclaringClass() {
+    match(Address.class, String.class, "home").to("homeAddress").assertNoMatch();
+    match(Address.class, String.class, "home").to("home", "address").assertNoMatch();
+  }
+
+  /**
+   * <pre>
+   * Address address -> addressAddress
+   * Address address -> address/address
+   * Address address/String address -> address
+   * Address address/String address -> addressAddress
+   * Address address/Object address/String foo -> addressFoo
+   * </pre>
+   */
+  public void shouldNotMatchSameTokenTwice() {
+    match(Address.class, "address").to("addressAddress").assertNoMatch();
+    match(Address.class, "address").to("address", "address").assertNoMatch();
+    match(Address.class, "address").$(String.class, "address").to("address").assertNoMatch();
+    match(Object.class, "address").$(String.class, "address").to("address").assertNoMatch();
+    match(Address.class, "address").$(Object.class, "address")
+        .$(String.class, "foo")
+        .to("addressFoo")
+        .assertNoMatch();
+  }
+
+  /**
+   * <pre>
+   * a/c -> 
+   * </pre>
+   */
+  public void shouldNotMatchSplitTokens() {
+    match(Address.class, "address").to("addressAddress").assertNoMatch();
+  }
+
+  /**
+   * <pre>
+   * Address address matches address
+   * </pre>
+   */
+  public void shouldMatchWithSameNameAndClassName() {
+    match(Address.class, "address").to("address").assertMatch();
+  }
+
+  /**
+   * <pre>
+   * Address value <> address
+   * </pre>
+   */
+  public void shouldNotMatchClassAlone() {
+    match(String.class, "value").to("address").assertNoMatch();
+  }
+
+  /**
+   * <pre>
+   * abc -> a/B/C
+   * aa/bb/cc -> aabb
+   * street/address -> streetaddress
+   * streetaddress -> street/address
+   * </pre>
+   */
+  public void shouldNotMatchCombinedTokens() {
+    match("aabbcc").to("aaBbCc").assertNoMatch();
+    match("ooAaBbCc").to("aabb").assertNoMatch();
+    match("streetAddress").to("streetaddress").assertNoMatch();
+    match("streetaddress").to("streetAddress").assertNoMatch();
+  }
+}


### PR DESCRIPTION
Hello all.

Let me start by saying a big thank you for such a good library.

Before some time, we had a requirement for the project I was working on, where we needed both flat and nested DTO/Request structures. Of course, mapping between them became a pain, since no MatchingStrategy properly maps 1:1 between flat and nested structures, and it was crucial not to have an overly/underly mapped destination DTO.
We started creating custom converters and soon enough, we had a converter for each flat -> nested and nested -> flat mapping.

I then came up with a new MatchingStrategy, named StrictFlatNestedMatchingStrategy (SFNMT) for this purpose.

This is a Strict MatchingStrategy that takes all nested tokens and compares them. It maps 1:1 between Flat to Flat, Nested to Nested, Flat to Nested, and Nested to Flat.

This code has been heavily tested on our project and works without any issues (that we have found).

I am sharing this code in the hope that it will help someone with the same issues we had.

Basic performance test done on all MatchingStrategies:
Standard matching strategy total execution time for [10000] mappings: [3425]ms
Loose matching strategy total execution time for [10000] mappings: [2731]ms
StrictFlatNested matching strategy total execution time for [10000] mappings: [2079]ms
Strict matching strategy total execution time for [10000] mappings: [2042]ms

All suggestions on how to further improve this matching strategy are welcome!