### PR TITLE
Fix bug #748

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
@@ -37,6 +37,7 @@ import org.modelmapper.spi.Mapping;
 import org.modelmapper.spi.MappingContext;
 import org.modelmapper.spi.MappingEngine;
 import org.modelmapper.spi.PropertyMapping;
+import org.modelmapper.spi.SourceMapping;
 
 /**
  * MappingEngine implementation that caches ConditionalConverters by source and destination type
@@ -206,6 +207,8 @@ public class MappingEngineImpl implements MappingEngine {
       }
     } else if (mapping instanceof ConstantMapping) {
       source = ((ConstantMapping) mapping).getConstant();
+      context.addParentSource("", source);
+    } else if (mapping instanceof SourceMapping ) {
       context.addParentSource("", source);
     }
     return source;

--- a/core/src/test/java/org/modelmapper/bugs/MultipleSourcePropertiesToNestedTargetPropertyTest.java
+++ b/core/src/test/java/org/modelmapper/bugs/MultipleSourcePropertiesToNestedTargetPropertyTest.java
@@ -11,7 +11,7 @@ import static org.testng.Assert.assertNotNull;
 import org.testng.annotations.Test;
 
 /**
- * @author Jonathan Halterman
+ * @author Fabian Landwehr
  */
 @Test
 public class MultipleSourcePropertiesToNestedTargetPropertyTest extends AbstractTest {

--- a/core/src/test/java/org/modelmapper/bugs/MultipleSourcePropertiesToNestedTargetPropertyTest.java
+++ b/core/src/test/java/org/modelmapper/bugs/MultipleSourcePropertiesToNestedTargetPropertyTest.java
@@ -1,0 +1,107 @@
+package org.modelmapper.bugs;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.Converter;
+import org.modelmapper.Fixtures;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.modelmapper.spi.DestinationSetter;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import org.testng.annotations.Test;
+
+/**
+ * @author Jonathan Halterman
+ */
+@Test
+public class MultipleSourcePropertiesToNestedTargetPropertyTest extends AbstractTest {
+
+  public static class Source {
+    private String firstName;
+    private String lastName;
+
+    public String getFirstName() {
+      return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+      this.firstName = firstName;
+    }
+
+    public String getLastName() {
+      return lastName;
+    }
+
+    public void setLastName(String lastName) {
+      this.lastName = lastName;
+    }
+
+    public Source getSelf() {
+      return this;
+    }
+
+  }
+
+  public static class TargetParent {
+    private TargetChild targetChild;
+
+    public TargetChild getTargetChild() {
+      return targetChild;
+    }
+
+    public void setTargetChild(TargetChild targetChild) {
+      this.targetChild = targetChild;
+    }
+
+  }
+
+  public static class TargetChild {
+    private String fullName;
+
+    public String getFullName() {
+      return fullName;
+    }
+
+    public void setFullName(String fullName) {
+      this.fullName = fullName;
+    }
+
+  }
+
+  public void shouldBehaveTheSameForBothSourceGetters() {
+    ModelMapper modelMapper1 = Fixtures.createModelMapper();
+    ModelMapper modelMapper2 = Fixtures.createModelMapper();
+
+    TypeMap<Source, TargetParent> typeMap1 = modelMapper1.createTypeMap(Source.class, TargetParent.class);
+    TypeMap<Source, TargetParent> typeMap2 = modelMapper2.createTypeMap(Source.class, TargetParent.class);
+
+    Converter<Source, String> converter = context -> {
+      Source source = context.getSource();
+      return source.getFirstName() + " " + source.getLastName();
+    };
+
+    DestinationSetter<TargetParent, String> destinationSetter = (dest, val) -> dest.getTargetChild().setFullName(val);
+
+    typeMap1.addMappings(mapper -> {
+      mapper.using(converter).<String>map(src -> src.getSelf(), destinationSetter);
+    });
+
+    typeMap2.addMappings(mapper -> {
+      mapper.using(converter).<String>map(src -> src, destinationSetter);
+    });
+
+    Source source = new Source();
+    source.setFirstName("foo");
+    source.setLastName("bar");
+
+    TargetParent target1 = modelMapper1.map(source, TargetParent.class);
+    TargetParent target2 = modelMapper2.map(source, TargetParent.class);
+
+    assertNotNull(target1.getTargetChild());
+    assertNotNull(target2.getTargetChild());
+    assertEquals(
+        target1.getTargetChild().getFullName(),
+        target2.getTargetChild().getFullName());
+  }
+
+}


### PR DESCRIPTION
This pull request fixes bug #748. 

The issue was that `context.addParentSource("", source);` was missing in one implicit case of an if-else-statement in https://github.com/modelmapper/modelmapper/commit/6f2d6fa3e5e78b38ea3153d1f35fb855b1ab8476

