### PR TITLE
Upgrading version for surefire and h2 dependencies to resolve Vulnerabilities

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <version>2.2.220</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -106,7 +107,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>3.4.0</version>
         <configuration>
           <suiteXmlFiles>
             <suiteXmlFile>src/test/resources/testngAll.xml</suiteXmlFile>


### PR DESCRIPTION
## Description
Upgrading dependencies version to resolve vulnerabilities here https://mvnrepository.com/artifact/org.modelmapper/modelmapper/3.2.0

## Issues Resolved
Closes [#745
](https://github.com/modelmapper/modelmapper/issues/745)

### Reason
Migrating to these versions will resolve the critical vulnerabilities, so that the clients will not have to handle explicitly. 

