### PR TITLE
Support Java 23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <cglib.version>3.3.0</cglib.version>
-    <asm.version>9.6</asm.version>
+    <asm.version>9.7.1</asm.version>
     <objenesis.version>3.2</objenesis.version>
     <typetools.version>0.6.3</typetools.version>
-    <bytebuddy.version>1.14.9</bytebuddy.version>
+    <bytebuddy.version>1.15.10</bytebuddy.version>
     <javassist.version>3.12.1.GA</javassist.version>
     <h2.version>2.2.220</h2.version>
     <hibernate.version>5.6.3.Final</hibernate.version>


### PR DESCRIPTION
The versions of ByteBuddy and ASM were changed for the latest ones that supports Java 23.

Best regards