### PR TITLE
Issue #759: Support for extendable proxy discovery based on plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ _site/
 user-manual/
 *.iml
 .idea/
+dependency-reduced-pom.xml
+

--- a/core/src/main/java/org/modelmapper/ModelMapper.java
+++ b/core/src/main/java/org/modelmapper/ModelMapper.java
@@ -576,7 +576,7 @@ public class ModelMapper {
   private <S, D> TypeMap<S, D> createTypeMapInternal(S source, Class<S> sourceType,
       Class<D> destinationType, String typeMapName, Configuration configuration) {
     if (source != null)
-      sourceType = Types.<S>deProxy(source.getClass());
+      sourceType = Types.<S>deProxiedClass(source);
     Assert.state(config.typeMapStore.get(sourceType, destinationType, typeMapName) == null,
         "A TypeMap already exists for %s and %s", sourceType, destinationType);
     return config.typeMapStore.create(source, sourceType, destinationType, typeMapName,
@@ -585,8 +585,8 @@ public class ModelMapper {
 
   private <D> D mapInternal(Object source, D destination, Type destinationType, String typeMapName) {
     if (destination != null)
-      destinationType = Types.<D>deProxy(destination.getClass());
-    return engine.<Object, D>map(source, Types.<Object>deProxy(source.getClass()), destination,
+      destinationType = Types.<D>deProxiedClass(destination);
+    return engine.<Object, D>map(source, Types.<Object>deProxiedClass(source), destination,
         TypeToken.<D>of(destinationType), typeMapName);
   }
 }

--- a/core/src/main/java/org/modelmapper/internal/ConstantMappingImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/ConstantMappingImpl.java
@@ -64,6 +64,6 @@ class ConstantMappingImpl extends MappingImpl implements ConstantMapping {
 
   @Override
   public Class<?> getSourceType() {
-    return constant == null ? Object.class : Types.deProxy(constant.getClass());
+    return constant == null ? Object.class : Types.deProxiedClass(constant);
   }
 }

--- a/core/src/main/java/org/modelmapper/internal/ExplicitMappingBuilder.java
+++ b/core/src/main/java/org/modelmapper/internal/ExplicitMappingBuilder.java
@@ -344,7 +344,7 @@ public class ExplicitMappingBuilder<S, D> implements ConditionExpression<S, D> {
     if (sourceValue != null) {
       if (sourceValue == source)
         options.mapFromSource = true;
-      else if (!Types.isProxied(sourceValue.getClass()))
+      else if (!Types.isProxied(sourceValue))
         sourceConstant = sourceValue;
     }
   }

--- a/core/src/main/java/org/modelmapper/internal/MappingContextImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingContextImpl.java
@@ -128,8 +128,8 @@ public class MappingContextImpl<S, D> implements MappingContext<S, D>, Provision
     Assert.notNull(source, "source");
     Assert.notNull(destination, "destination");
 
-    return new MappingContextImpl<CS, CD>(this, source, Types.<CS>deProxy(source.getClass()),
-        destination, Types.<CD>deProxy(destination.getClass()), null, mapping, false);
+    return new MappingContextImpl<CS, CD>(this, source, Types.<CS>deProxiedClass(source),
+        destination, Types.<CD>deProxiedClass(destination), null, mapping, false);
   }
 
   /** Creates a child MappingContext for an element of a destination collection. */
@@ -138,7 +138,7 @@ public class MappingContextImpl<S, D> implements MappingContext<S, D>, Provision
     Assert.notNull(source, "source");
     Assert.notNull(destinationType, "destinationType");
 
-    return new MappingContextImpl<CS, CD>(this, source, Types.<CS>deProxy(source.getClass()), null,
+    return new MappingContextImpl<CS, CD>(this, source, Types.<CS>deProxiedClass(source), null,
         destinationType, null, null, false);
   }
 
@@ -153,7 +153,7 @@ public class MappingContextImpl<S, D> implements MappingContext<S, D>, Provision
     Assert.notNull(destinationType, "destinationType");
     TypeToken<CD> destinationTypeToken = TypeToken.of(destinationType);
 
-    return new MappingContextImpl<CS, CD>(this, source, Types.<CS>deProxy(source.getClass()), null,
+    return new MappingContextImpl<CS, CD>(this, source, Types.<CS>deProxiedClass(source), null,
         destinationTypeToken.getRawType(), destinationTypeToken.getType(), mapping, false);
   }
 

--- a/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/MappingEngineImpl.java
@@ -269,7 +269,7 @@ public class MappingEngineImpl implements MappingEngine {
       Object source, MappingImpl mapping) {
     Class<?> sourceType = mapping.getSourceType();
     if (source != null)
-      sourceType = Types.deProxy(source.getClass());
+      sourceType = Types.deProxiedClass(source);
     boolean cyclic = mapping instanceof PropertyMapping && ((PropertyMappingImpl) mapping).cyclic;
     Class<Object> destinationType = (Class<Object>) mapping.getLastDestinationProperty().getType();
     Type genericDestinationType = context.genericDestinationPropertyType(mapping.getLastDestinationProperty().getGenericType());

--- a/core/src/main/java/org/modelmapper/internal/TypeMapImpl.java
+++ b/core/src/main/java/org/modelmapper/internal/TypeMapImpl.java
@@ -177,7 +177,7 @@ class TypeMapImpl<S, D> implements TypeMap<S, D> {
 
   @Override
   public D map(S source) {
-    Class<S> sourceType = Types.deProxy(source.getClass());
+    Class<S> sourceType = Types.deProxiedClass(source);
     MappingContextImpl<S, D> context = new MappingContextImpl<S, D>(source, sourceType, null,
         destinationType, null, name, engine);
     D result = null;
@@ -194,7 +194,7 @@ class TypeMapImpl<S, D> implements TypeMap<S, D> {
 
   @Override
   public void map(S source, D destination) {
-    Class<S> sourceType = Types.deProxy(source.getClass());
+    Class<S> sourceType = Types.deProxiedClass(source);
     MappingContextImpl<S, D> context = new MappingContextImpl<S, D>(source, sourceType,
         destination, destinationType, null, name, engine);
 

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/AbstractByteCodeEnhancedProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/AbstractByteCodeEnhancedProxyDiscoveryPlugin.java
@@ -1,0 +1,12 @@
+package org.modelmapper.internal.util.plugins;
+
+import java.util.regex.Pattern;
+
+public abstract class AbstractByteCodeEnhancedProxyDiscoveryPlugin extends AbstractProxyDiscoveryPlugin {
+    @Override
+    protected boolean isProxiedClass(Class<?> objectClass) {
+        return getProxyTypePattern().matcher(objectClass.getSimpleName()).matches();
+    }
+
+    protected abstract Pattern getProxyTypePattern();
+}

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/AbstractProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/AbstractProxyDiscoveryPlugin.java
@@ -1,0 +1,23 @@
+package org.modelmapper.internal.util.plugins;
+
+public abstract class AbstractProxyDiscoveryPlugin implements ProxyDiscoveryPlugin {
+
+    @Override
+    public Object getProxyTarget(Object object) {
+        final Class<?> objectClass = object instanceof Class ? (Class<?>) object : object.getClass();
+        if (isProxiedClass(objectClass)) {
+            final Class<?> superClass = objectClass.getSuperclass();
+            if (superClass == Object.class || superClass == null) {
+                final Class<?>[] interfaces = objectClass.getInterfaces();
+                if (interfaces.length > 0) {
+                    return interfaces[0];
+                }
+            } else {
+                return superClass;
+            }
+        }
+        return null;
+    }
+
+    protected abstract boolean isProxiedClass(Class<?> objectClass);
+}

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/ByteBuddyProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/ByteBuddyProxyDiscoveryPlugin.java
@@ -1,0 +1,11 @@
+package org.modelmapper.internal.util.plugins;
+
+import java.util.regex.Pattern;
+
+public class ByteBuddyProxyDiscoveryPlugin extends AbstractByteCodeEnhancedProxyDiscoveryPlugin {
+    private final Pattern pattern = Pattern.compile(".*\\$ByteBuddy\\$.*");
+    @Override
+    protected Pattern getProxyTypePattern() {
+        return pattern;
+    }
+}

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/EnhancerProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/EnhancerProxyDiscoveryPlugin.java
@@ -1,0 +1,11 @@
+package org.modelmapper.internal.util.plugins;
+
+import java.util.regex.Pattern;
+
+public class EnhancerProxyDiscoveryPlugin extends AbstractByteCodeEnhancedProxyDiscoveryPlugin {
+    private final Pattern pattern = Pattern.compile(".*\\$\\$EnhancerBy.*");
+    @Override
+    protected Pattern getProxyTypePattern() {
+        return pattern;
+    }
+}

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/HibernateProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/HibernateProxyDiscoveryPlugin.java
@@ -1,0 +1,11 @@
+package org.modelmapper.internal.util.plugins;
+
+import java.util.regex.Pattern;
+
+public class HibernateProxyDiscoveryPlugin extends AbstractByteCodeEnhancedProxyDiscoveryPlugin {
+    private final Pattern pattern = Pattern.compile(".*\\$HibernateProxy\\$.*");
+    @Override
+    protected Pattern getProxyTypePattern() {
+        return pattern;
+    }
+}

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/JavaAssistProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/JavaAssistProxyDiscoveryPlugin.java
@@ -1,0 +1,30 @@
+package org.modelmapper.internal.util.plugins;
+
+import org.modelmapper.internal.util.Types;
+
+import java.lang.reflect.Method;
+
+public class JavaAssistProxyDiscoveryPlugin extends AbstractProxyDiscoveryPlugin {
+
+    private Method isProxyMethod;
+
+    public JavaAssistProxyDiscoveryPlugin() {
+        try {
+            Class<?> factoryClass = Types.class.getClassLoader().loadClass(
+                    "javassist.util.proxy.ProxyFactory");
+            isProxyMethod = factoryClass.getMethod("isProxyClass",
+                    new Class<?>[]{Class.class});
+        } catch (Exception ignore) {
+        }
+    }
+
+    @Override
+    protected boolean isProxiedClass(Class<?> objectClass) {
+        try {
+            return isProxyMethod != null
+                    && (Boolean) isProxyMethod.invoke(null, objectClass);
+        } catch (Exception ignore) {
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/JavaProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/JavaProxyDiscoveryPlugin.java
@@ -1,0 +1,17 @@
+package org.modelmapper.internal.util.plugins;
+
+import java.lang.reflect.Proxy;
+
+public class JavaProxyDiscoveryPlugin implements ProxyDiscoveryPlugin {
+    @Override
+    public Object getProxyTarget(Object object) {
+        if (Proxy.isProxyClass(object.getClass())) {
+            final Class<?>[] interfaces = object.getClass().getInterfaces();
+            if (interfaces.length == 0) {
+                return null;
+            }
+            return interfaces[0];
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/MockitoProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/MockitoProxyDiscoveryPlugin.java
@@ -1,0 +1,11 @@
+package org.modelmapper.internal.util.plugins;
+
+import java.util.regex.Pattern;
+
+public class MockitoProxyDiscoveryPlugin extends AbstractByteCodeEnhancedProxyDiscoveryPlugin {
+    private final Pattern pattern = Pattern.compile(".*\\$MockitoMock\\$.*");
+    @Override
+    protected Pattern getProxyTypePattern() {
+        return pattern;
+    }
+}

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/PermazenProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/PermazenProxyDiscoveryPlugin.java
@@ -1,0 +1,11 @@
+package org.modelmapper.internal.util.plugins;
+
+import java.util.regex.Pattern;
+
+public class PermazenProxyDiscoveryPlugin extends AbstractByteCodeEnhancedProxyDiscoveryPlugin {
+    private final Pattern pattern = Pattern.compile(".*\\$\\$Permazen.*");
+    @Override
+    protected Pattern getProxyTypePattern() {
+        return pattern;
+    }
+}

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/ProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/ProxyDiscoveryPlugin.java
@@ -1,0 +1,15 @@
+package org.modelmapper.internal.util.plugins;
+
+/**
+ * Plugin for detecting proxies objects.
+ */
+public interface ProxyDiscoveryPlugin {
+    /**
+     * Gets the target for the proxy or null if no proxy could be discovered for the specified object.
+     * The returned target can be a class or an object (instance of a specific concrete class).
+     *
+     * @param object The object or class to get the proxy target for
+     * @return The target of the proxy or null if not detectable by this plugin.
+     */
+    Object getProxyTarget(Object object);
+}

--- a/core/src/main/java/org/modelmapper/internal/util/plugins/SpringCglibProxyDiscoveryPlugin.java
+++ b/core/src/main/java/org/modelmapper/internal/util/plugins/SpringCglibProxyDiscoveryPlugin.java
@@ -1,0 +1,11 @@
+package org.modelmapper.internal.util.plugins;
+
+import java.util.regex.Pattern;
+
+public class SpringCglibProxyDiscoveryPlugin extends AbstractByteCodeEnhancedProxyDiscoveryPlugin {
+    private final Pattern pattern = Pattern.compile(".*\\$\\$SpringCGLIB.*");
+    @Override
+    protected Pattern getProxyTypePattern() {
+        return pattern;
+    }
+}

--- a/core/src/test/java/org/modelmapper/internal/util/TypesTest.java
+++ b/core/src/test/java/org/modelmapper/internal/util/TypesTest.java
@@ -38,26 +38,26 @@ public class TypesTest {
     }
   }
 
-  public void shouldDeProxyJavassistProxy() {
+  public void shouldDeProxyJavassistProxy() throws Exception {
     ProxyFactory proxyFactory = new ProxyFactory();
     proxyFactory.setSuperclass(Foo.class);
-    Class<?> proxy = proxyFactory.createClass();
+    Object proxy = proxyFactory.create(new Class[0], new Object[0]);
 
-    assertEquals(Types.deProxy(proxy), Foo.class);
+    assertEquals(Types.deProxiedClass(proxy), Foo.class);
   }
 
   public void shouldDeProxyCGLibProxy() {
     Enhancer enhancer = new Enhancer();
     enhancer.setSuperclass(ArrayList.class);
     enhancer.setCallbackTypes(new Class[] { NoOp.class });
-    Class<?> proxy = enhancer.createClass();
+    Object proxy = enhancer.create();
 
-    assertEquals(Types.deProxy(proxy), ArrayList.class);
+    assertEquals(Types.deProxiedClass(proxy), ArrayList.class);
   }
 
   public void shouldDeProxyDynamicProxy() {
     final Object proxy = Proxy.newProxyInstance(TypesTest.class.getClassLoader(),
             new Class<?>[]{Bar.class}, new NullInvocationHandler());
-    assertEquals(Types.deProxy(proxy.getClass()), Bar.class);
+    assertEquals(Types.deProxiedClass(proxy), Bar.class);
   }
 }


### PR DESCRIPTION
This PR adds support for proxy proxy discovery based on plugins which can be registered by the user of the library.

A set of default plugins (the same which were already used and a new one for SpringCGLIB) are already registered.