### PR TITLE
Bump `org.testing` to 7.5.1 due to CVE. Fixes #758

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 3.2.3
+
+* Bump `org.testing` to 7.5.1 due to CVE
+
 # 3.2.0
 
 * Bump asm and byte-buddy for JDK 21 support

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <h2.version>2.2.220</h2.version>
     <hibernate.version>5.6.3.Final</hibernate.version>
     <slf4j.version>1.5.8</slf4j.version>
-    <testng.version>7.5</testng.version>
+    <testng.version>7.5.1</testng.version>
     <mockito.version>4.2.0</mockito.version>
     <dozer.version>5.5.1</dozer.version>
     <orika.version>1.5.4</orika.version>


### PR DESCRIPTION
Bump `org.testing` to 7.5.1 due to CVE