### PR TITLE
Fix Hibernate proxy issue

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/util/Types.java
+++ b/core/src/main/java/org/modelmapper/internal/util/Types.java
@@ -76,7 +76,7 @@ public final class Types {
       return true;
     if (type.getName().contains("$$EnhancerBy"))
       return true;
-    if (type.getName().contains("$HibernateProxy$"))
+    if (type.getName().contains("$HibernateProxy"))
       return true;
     if (type.getName().contains("$MockitoMock$"))
       return true;


### PR DESCRIPTION
As a result of this change in Hibernate:
https://hibernate.atlassian.net/browse/HHH-14694

The hibernate proxy class names no longer have a `$` at the end, and so this `isProxied` check fails, resulting in the typeMap not being properly fetched and some mapping errors. 

Here is a screenshot of the class name when using hibernate 6.6.12 and above:
![image](https://github.com/user-attachments/assets/ee64ec39-8686-4eff-90b5-55ac2b8cca71)

