### PR TITLE
Filter out META-INF/versions/** from shaded dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -101,6 +101,14 @@
               <shadedPattern>org.modelmapper.internal.typetools</shadedPattern>
             </relocation>
           </relocations>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/versions/**</exclude>
+              </excludes>
+            </filter>
+          </filters>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This PR excludes META-INF/versions/** folders from shaded dependencies (such as Byte Buddy).
See https://github.com/raphw/byte-buddy?tab=readme-ov-file#dependency-and-api-evolution
for official recommendation.

Fixes #770